### PR TITLE
Revert "Set bar style correctly"

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/EhActivity.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/EhActivity.kt
@@ -19,6 +19,7 @@ import android.content.res.Resources.Theme
 import android.os.Bundle
 import androidx.annotation.StyleRes
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
 import androidx.navigation.ActivityNavigator
 import com.hippo.ehviewer.R
 import com.hippo.ehviewer.Settings
@@ -45,6 +46,8 @@ abstract class EhActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         layoutInflater.factory2 = LayoutInflaterFactory(delegate).addOnViewCreatedListener(WindowInsetsHelper.LISTENER)
         super.onCreate(savedInstanceState)
+        WindowCompat.getInsetsController(window, window.decorView).isAppearanceLightStatusBars = !isNightMode()
+        WindowCompat.getInsetsController(window, window.decorView).isAppearanceLightNavigationBars = !isNightMode()
     }
 
     override fun onResume() {

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -29,11 +29,9 @@
         <item name="windowNoTitle">true</item>
 
         <!-- Transparent Status Bar -->
-        <item name="android:windowLightStatusBar">?isLightTheme</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
 
         <!-- Transparent Navigation Bar -->
-        <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">?isLightTheme</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:enforceNavigationBarContrast" tools:targetApi="q">false</item>
 


### PR DESCRIPTION
This reverts 216a04309408684c141db1d34114f271cf20cc01.

Reason for revert: Incorrect status bar color when app's night mode setting is different from system's

CC: @nullArrayList