### PR TITLE
Avoid race condition when updating tag database

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/EhApplication.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/EhApplication.kt
@@ -91,7 +91,7 @@ class EhApplication : Application(), ImageLoaderFactory {
                 migrateCookies()
             }
             launchIO {
-                EhTagDatabase.update()
+                EhTagDatabase
             }
             launchIO {
                 EhDB


### PR DESCRIPTION
`updateInternal` and `issueUpdateInMemoryData` will try to create tag database directory at the same time on first launch and one of them will fail, causing app crash