### PR TITLE
Fix FAB not collapsing with no selected items

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/DownloadsScreen.kt
@@ -44,13 +44,13 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDismissState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -114,12 +114,9 @@ fun DownloadsScreen(navigator: DestinationsNavigator) {
     var filterType by rememberSaveable { mutableStateOf(-1) }
     var searchBarOffsetY by remember { mutableStateOf(0) }
     val searchFieldState = rememberTextFieldState()
-    var selectMode by remember { mutableStateOf(false) }
-    LockDrawer(selectMode)
     val checkedInfoMap = remember { mutableStateMapOf<Long, DownloadInfo>() }
-    SideEffect {
-        if (checkedInfoMap.isEmpty()) selectMode = false
-    }
+    val selectMode by rememberUpdatedState(checkedInfoMap.isNotEmpty())
+    LockDrawer(selectMode)
 
     val context = LocalContext.current
     val activity = remember(context) { context.findActivity<MainActivity>() }
@@ -313,7 +310,7 @@ fun DownloadsScreen(navigator: DestinationsNavigator) {
         searchFieldHint = hint,
         showSearchFab = selectMode,
         onApplySearch = { keyword = it.takeUnless { it.isBlank() } },
-        onSearchExpanded = { selectMode = false },
+        onSearchExpanded = { checkedInfoMap.clear() },
         onSearchHidden = {},
         searchBarOffsetY = { searchBarOffsetY },
         trailingIcon = {
@@ -446,7 +443,6 @@ fun DownloadsScreen(navigator: DestinationsNavigator) {
                             },
                             onLongClick = {
                                 checkedInfoMap[info.gid] = info
-                                selectMode = true
                             },
                             onStart = {
                                 val intent = Intent(activity, DownloadService::class.java)
@@ -492,10 +488,7 @@ fun DownloadsScreen(navigator: DestinationsNavigator) {
     FabLayout(
         hidden = !selectMode,
         expanded = selectMode,
-        onExpandChanged = {
-            checkedInfoMap.clear()
-            selectMode = false
-        },
+        onExpandChanged = { checkedInfoMap.clear() },
         autoCancel = false,
     ) {
         onClick(Icons.Default.DoneAll) {


### PR DESCRIPTION
There is still an issue though: when exiting selection mode, secondary FABs recompose before collapsing.