### PR TITLE
Revert "Move to Apache5 HC instead"

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ and [Dynamic Color](https://m3.material.io/styles/color/dynamic-color/overview) 
 
 \* Archives and GIFs are not supported
 
-** Fall back to Apache5 on devices that don't support [HttpEngine](https://developer.android.com/reference/android/net/http/HttpEngine)
+** Fall back to CIO on devices that don't support [HttpEngine](https://developer.android.com/reference/android/net/http/HttpEngine)
 
 <a href="https://github.com/FooIbar/EhViewer/releases">
 <img alt="Get it on GitHub" src="https://github.com/Ehviewer-Overhauled/Art/blob/master/get-it-on-github.svg" width="200px"/>

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -14,14 +14,6 @@
 # Ktor logger
 -dontwarn org.slf4j.impl.StaticLoggerBinder
 
-# Apache5 Http Client
--dontwarn org.ietf.jgss.GSSContext
--dontwarn org.ietf.jgss.GSSCredential
--dontwarn org.ietf.jgss.GSSException
--dontwarn org.ietf.jgss.GSSManager
--dontwarn org.ietf.jgss.GSSName
--dontwarn org.ietf.jgss.Oid
-
 -dontwarn org.conscrypt.Conscrypt
 
 -allowaccessmodification

--- a/app/src/main/kotlin/com/hippo/ehviewer/EhApplication.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/EhApplication.kt
@@ -49,6 +49,7 @@ import com.hippo.ehviewer.util.AppConfig
 import com.hippo.ehviewer.util.Crash
 import com.hippo.ehviewer.util.FavouriteStatusRouter
 import com.hippo.ehviewer.util.FileUtils
+import com.hippo.ehviewer.util.NoopX509TrustManager
 import com.hippo.ehviewer.util.ReadableTime
 import com.hippo.ehviewer.util.isAtLeastP
 import com.hippo.ehviewer.util.isAtLeastS
@@ -57,7 +58,7 @@ import eu.kanade.tachiyomi.util.lang.launchIO
 import eu.kanade.tachiyomi.util.lang.withUIContext
 import eu.kanade.tachiyomi.util.system.logcat
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.apache5.Apache5
+import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.cookies.HttpCookies
 import kotlinx.coroutines.launch
 import okio.Path.Companion.toOkioPath
@@ -178,7 +179,12 @@ class EhApplication : Application(), SingletonImageLoader.Factory {
                     }
                 }
             } else {
-                HttpClient(Apache5) {
+                HttpClient(CIO) {
+                    engine {
+                        https {
+                            trustManager = NoopX509TrustManager
+                        }
+                    }
                     install(HttpCookies) {
                         storage = EhCookieStore
                     }

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/settings/AdvancedScreen.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/settings/AdvancedScreen.kt
@@ -142,7 +142,7 @@ fun AdvancedScreen(navigator: DestinationsNavigator) {
             var enableCronet by Settings::enableCronet.observed
             Preference(
                 title = stringResource(id = R.string.settings_advanced_http_engine),
-                summary = if (enableCronet) "Cronet" else "Apache 5",
+                summary = if (enableCronet) "Cronet" else "CIO",
             ) {
                 coroutineScope.launch {
                     dialogState.awaitPermissionOrCancel(
@@ -156,7 +156,7 @@ fun AdvancedScreen(navigator: DestinationsNavigator) {
                                     onClick = { enableCronet = false },
                                     shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
                                 ) {
-                                    Text("Apache 5")
+                                    Text("CIO")
                                 }
                                 SegmentedButton(
                                     selected = enableCronet,

--- a/app/src/main/kotlin/com/hippo/ehviewer/util/NoopX509TrustManager.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/util/NoopX509TrustManager.kt
@@ -1,0 +1,12 @@
+package com.hippo.ehviewer.util
+
+import android.annotation.SuppressLint
+import java.security.cert.X509Certificate
+import javax.net.ssl.X509TrustManager
+
+@SuppressLint("CustomX509TrustManager")
+object NoopX509TrustManager : X509TrustManager {
+    override fun checkClientTrusted(p0: Array<out X509Certificate>, p1: String) = Unit
+    override fun checkServerTrusted(p0: Array<out X509Certificate>, p1: String) = Unit
+    override fun getAcceptedIssuers() = emptyArray<X509Certificate>()
+}

--- a/docs/README/zh-cn.md
+++ b/docs/README/zh-cn.md
@@ -74,7 +74,7 @@
 
 \* 不支持压缩包和 GIF
 
-** 在不支持 [HttpEngine](https://developer.android.com/reference/android/net/http/HttpEngine) 的设备上回退到 Apache5
+** 在不支持 [HttpEngine](https://developer.android.com/reference/android/net/http/HttpEngine) 的设备上回退到 CIO
 
 <a href="https://github.com/FooIbar/EhViewer/releases">
 <img alt="Get it on GitHub" src="https://github.com/Ehviewer-Overhauled/Art/blob/master/get-it-on-github.svg" width="200px"/>

--- a/docs/README/zh-tw.md
+++ b/docs/README/zh-tw.md
@@ -74,7 +74,7 @@
 
 \* 不支援壓縮包和 GIF
 
-** 在不支援 [HttpEngine](https://developer.android.com/reference/android/net/http/HttpEngine) 的裝置上回退到 Apache5
+** 在不支援 [HttpEngine](https://developer.android.com/reference/android/net/http/HttpEngine) 的裝置上回退到 CIO
 
 <a href="https://github.com/FooIbar/EhViewer/releases">
 <img alt="Get it on GitHub" src="https://github.com/Ehviewer-Overhauled/Art/blob/master/get-it-on-github.svg" width="200px"/>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -95,7 +95,7 @@ kotlinx-serialization-json-okio = { module = "org.jetbrains.kotlinx:kotlinx-seri
 # For renovate
 ktlint = { module = "com.pinterest:ktlint", version.ref = "ktlint" }
 
-ktor-client-apache5 = { module = "io.ktor:ktor-client-apache5", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 
 material = { module = "com.google.android.material:material", version.ref = "google-android-material" }
 
@@ -118,7 +118,7 @@ coil = ["coil-compose", "coil-gif"]
 compose = ["compose-foundation", "compose-material-icons-extended", "compose-material3", "compose-material3-windowsizeclass", "compose-ui-util"]
 cronet = ["cronet-api", "cronet-gms"]
 kotlinx-serialization = ["kotlinx-serialization-cbor", "kotlinx-serialization-json", "kotlinx-serialization-json-okio"]
-ktor = ["ktor-client-apache5"]
+ktor = ["ktor-client-cio"]
 splitties = ["splitties-appctx", "splitties-arch-room", "splitties-preferences", "splitties-systemservices"]
 
 [plugins]


### PR DESCRIPTION
This reverts commit 6b41c112652eed61aa11783a4d21406f863a4f1f.

Reason for revert: `setApplicationProtocols` used by Apache 5 HC is not available until API 29.