### PR TITLE
Lazily initialize image cache of PageLoader

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/gallery/ArchivePageLoader.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/gallery/ArchivePageLoader.kt
@@ -71,6 +71,7 @@ class ArchivePageLoader(private val file: UniFile, passwdProvider: PasswdProvide
         private set
 
     override fun start() {
+        super.start()
         hostJob.start()
     }
 

--- a/app/src/main/kotlin/com/hippo/ehviewer/gallery/EhPageLoader.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/gallery/EhPageLoader.kt
@@ -28,6 +28,7 @@ import com.hippo.unifile.UniFile
 class EhPageLoader(private val mGalleryInfo: GalleryInfo) : PageLoader2(), OnSpiderListener {
     private lateinit var mSpiderQueen: SpiderQueen
     override fun start() {
+        super.start()
         if (!::mSpiderQueen.isInitialized) {
             mSpiderQueen = obtainSpiderQueen(mGalleryInfo, SpiderQueen.MODE_READ)
             mSpiderQueen.addOnSpiderListener(this)


### PR DESCRIPTION
`OSUtils.totalMemory` needs to read from disk