### PR TITLE
Migrate to Corrosion, rust-android-gradle is dead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@
 /local.properties
 .DS_Store
 /build
-/src
+/.kotlin
 *.iml
 .idea
 /captures
-google-services.json

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,8 +1,2 @@
 /build
-/src/main/java-gen
-manifest-merger-release-report.txt
-/src/main/libs
-/src/main/obj
-# Intellij
-*.iml
 /.cxx

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,6 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.spotless)
     alias(libs.plugins.aboutlibrariesPlugin)
-    alias(libs.plugins.rustAndroidPlugin)
     alias(libs.plugins.composeCompilerReportGenerator)
 }
 
@@ -290,13 +289,6 @@ aboutLibraries {
     duplicationRule = GROUP
 }
 
-cargo {
-    module = "src/main/rust"
-    libname = "ehviewer_rust"
-    targets = if (isRelease) listOf("arm", "x86", "arm64", "x86_64") else listOf("arm64", "x86_64")
-    if (isRelease) profile = "release"
-}
-
 spotless {
     kotlin {
         // https://github.com/diffplug/spotless/issues/111
@@ -305,13 +297,5 @@ spotless {
     }
     kotlinGradle {
         ktlint()
-    }
-}
-
-tasks.configureEach {
-    if (name.startsWith("merge") && name.endsWith("JniLibFolders")) {
-        dependsOn("cargoBuild")
-        // fix mergeDebugJniLibFolders  UP-TO-DATE
-        inputs.dir(layout.buildDirectory.dir("rustJniLibs/android"))
     }
 }

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -22,20 +22,22 @@ set(FETCHCONTENT_BASE_DIR ${deps})
 
 set(BUILD_TESTING 0)
 
-FetchContent_Declare(liblzma
+FetchContent_Declare(
+        liblzma
         GIT_REPOSITORY https://github.com/FooIbar/xz.git
         GIT_TAG v5.4.6
-        )
+)
 
 FetchContent_MakeAvailable(liblzma)
 include_directories(${liblzma_SOURCE_DIR}/src/liblzma/api)
 
 # Build GNUTLS libnettle
-FetchContent_Declare(nettle
+FetchContent_Declare(
+        nettle
         URL https://ftp.gnu.org/gnu/nettle/nettle-3.9.1.tar.gz
         URL_MD5 29fcd2dec6bf5b48e5e3ffb3cbc4779e
         SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/nettle/nettle
-        )
+)
 
 FetchContent_MakeAvailable(nettle)
 add_subdirectory(nettle)
@@ -67,14 +69,24 @@ option(ENABLE_TEST OFF)
 # Configure libarchive link's static lib
 SET(LIBARCHIVE_CUSTOM_LIBS "nettle" "liblzma")
 
-FetchContent_Declare(libarchive
+FetchContent_Declare(
+        libarchive
         GIT_REPOSITORY https://github.com/FooIbar/libarchive.git
         GIT_TAG v3.7.2
-        )
+)
 
 FetchContent_MakeAvailable(libarchive)
 include_directories(${libarchive_SOURCE_DIR}/libarchive)
 
+FetchContent_Declare(
+        Corrosion
+        GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
+        GIT_TAG v0.4.7
+)
+
+FetchContent_MakeAvailable(Corrosion)
+corrosion_import_crate(MANIFEST_PATH ../rust/Cargo.toml)
+
 # Build and link our app's native lib
 add_library(${PROJECT_NAME} SHARED archive.c border.c gifutils.c natsort/strnatcmp.c)
-target_link_libraries(${PROJECT_NAME} archive_static log jnigraphics)
+target_link_libraries(${PROJECT_NAME} ehviewer_rust archive_static log jnigraphics)

--- a/app/src/main/kotlin/com/hippo/ehviewer/EhApplication.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/EhApplication.kt
@@ -106,7 +106,6 @@ class EhApplication : Application(), SingletonImageLoader.Factory {
         }
         super.onCreate()
         System.loadLibrary("ehviewer")
-        System.loadLibrary("ehviewer_rust")
         ReadableTime.initialize(this)
         lifecycleScope.launchIO {
             launchIO {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.spotless) apply false
     alias(libs.plugins.aboutlibrariesPlugin) apply false
-    alias(libs.plugins.rustAndroidPlugin) apply false
     alias(libs.plugins.composeCompilerReportGenerator) apply false
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,7 @@ org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.configuration-cache=true
 android.useAndroidX=true
 android.enableAppCompileTimeRClass=true
 android.experimental.enableNewResourceShrinker.preciseShrinking=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.configuration-cache=true
+# org.gradle.configuration-cache=true
 android.useAndroidX=true
 android.enableAppCompileTimeRClass=true
 android.experimental.enableNewResourceShrinker.preciseShrinking=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -140,5 +140,4 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
-rustAndroidPlugin = { id = "org.mozilla.rust-android-gradle.rust-android", version = "0.9.3" }
 spotless = { id = "com.diffplug.spotless", version = "6.25.0" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,6 @@ dependencyResolutionManagement {
 }
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
-enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
+// enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
 rootProject.name = "EhViewer"
 include(":app")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,5 +19,6 @@ dependencyResolutionManagement {
 }
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
 rootProject.name = "EhViewer"
 include(":app")


### PR DESCRIPTION
~This also allows us to enable gradle configuration cache.~
Gradle configuration cache is disabled for now, will try enabling it in the future.