### PR TITLE
Enable compiler nonSkippingGroupOptimization

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -142,6 +142,7 @@ android {
             "-opt-in=splitties.preferences.DataStorePreferencesPreview",
 
             "-P", "plugin:androidx.compose.compiler.plugins.kotlin:experimentalStrongSkipping=true",
+            "-P", "plugin:androidx.compose.compiler.plugins.kotlin:nonSkippingGroupOptimization=true",
         )
     }
 


### PR DESCRIPTION
The problem occurs in https://github.com/androidx/androidx/commit/52835066c9044647a65dfb566f03131aab46e793 SlotTable modification.