### PR TITLE
Revert "Build with Android 15 preview SDK"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,6 @@ jobs:
           key: cmake-default-${{ hashFiles('gradle/libs.versions.toml', 'app/build.gradle.kts', 'app/src/main/cpp/CMakeLists.txt') }}
           restore-keys: cmake-default-
 
-      - name: Install Build Tools
-        run: echo "y" | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --install "build-tools;35.0.0-rc1"
-
       - name: Build OSS
         run: ./gradlew assembleDefaultOssRelease
 

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -36,9 +36,6 @@ jobs:
           key: ${{ runner.os }}-cmake-${{ hashFiles('gradle/libs.versions.toml', 'app/build.gradle.kts', 'app/src/main/cpp/CMakeLists.txt') }}
           restore-keys: ${{ runner.os }}-cmake-
 
-      - name: Install Build Tools
-        run: echo "y" | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --install "build-tools;35.0.0-rc1"
-
       - name: Gradle Build
         uses: gradle/actions/setup-gradle@v3
         with:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,8 +19,7 @@ plugins {
 }
 
 android {
-    compileSdkPreview = "VanillaIceCream"
-    buildToolsVersion = "35.0.0-rc1"
+    compileSdk = 34
     ndkVersion = "26.2.11394342"
 
     splits {

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,5 +22,3 @@ org.gradle.configuration-cache=true
 android.useAndroidX=true
 android.enableAppCompileTimeRClass=true
 android.experimental.enableNewResourceShrinker.preciseShrinking=true
-android.injected.testOnly=false
-android.suppressUnsupportedCompileSdk=VanillaIceCream


### PR DESCRIPTION
This reverts commit 7d2e0f7f

Reason for revert: Android SDK sources for VanillaIceCream are not available, making it hard to debug.