### PR TITLE
Don't crop borders for webtoons

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/coil/CropBorderInterceptor.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/coil/CropBorderInterceptor.kt
@@ -17,6 +17,7 @@ import com.hippo.ehviewer.image.detectBorder
 import com.hippo.ehviewer.util.isAtLeastO
 
 private const val CROP_THRESHOLD = 0.75f
+private const val WEBTOON_THRESHOLD = 3
 
 private val maybeCropBorderKey = Extras.Key(default = false)
 
@@ -47,23 +48,28 @@ object CropBorderInterceptor : Interceptor {
                 val image = result.image
                 if (image is BitmapImage) {
                     val bitmap = image.bitmap
-                    val array = detectBorder(bitmap)
-                    val r = IntRect(array[0], array[1], array[2], array[3])
-                    val minWidth = image.width * CROP_THRESHOLD
-                    val minHeight = image.height * CROP_THRESHOLD
-                    val maybeHwBitmap = if (hw) {
+                    val rect = if (image.height / image.width < WEBTOON_THRESHOLD) {
+                        val array = detectBorder(bitmap)
+                        val minWidth = image.width * CROP_THRESHOLD
+                        val minHeight = image.height * CROP_THRESHOLD
+                        IntRect(array[0], array[1], array[2], array[3]).takeIf {
+                            it.width > minWidth && it.height > minHeight
+                        }
+                    } else {
+                        null
+                    }
+                    val maybeHwImage = if (hw) {
                         // Upload to Graphical Buffer to accelerate render
                         // May fail if the image is too long
-                        bitmap.copy(Bitmap.Config.HARDWARE, false)?.apply {
+                        bitmap.copy(Bitmap.Config.HARDWARE, false)?.run {
                             bitmap.recycle()
-                        } ?: bitmap
+                            asCoilImage()
+                        } ?: image
                     } else {
-                        bitmap
+                        image
                     }
-                    val shouldOverride = r.width > minWidth && r.height > minHeight
-                    val maybeHwImage = maybeHwBitmap.asCoilImage()
-                    val new = if (shouldOverride) {
-                        BitmapImageWithRect(r, maybeHwImage)
+                    val new = if (rect != null) {
+                        BitmapImageWithRect(rect, maybeHwImage)
                     } else {
                         maybeHwImage
                     }


### PR DESCRIPTION
Webtoons are typically split across multiple pages, they require consistent width to maintain alignment.