### PR TITLE
Scale wide images (banners) to fit target width

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/coil/CropBorderInterceptor.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/coil/CropBorderInterceptor.kt
@@ -17,7 +17,7 @@ import com.hippo.ehviewer.image.detectBorder
 import com.hippo.ehviewer.util.isAtLeastO
 
 private const val CROP_THRESHOLD = 0.75f
-private const val WEBTOON_THRESHOLD = 3
+private const val RATIO_THRESHOLD = 2
 
 private val maybeCropBorderKey = Extras.Key(default = false)
 
@@ -48,7 +48,12 @@ object CropBorderInterceptor : Interceptor {
                 val image = result.image
                 if (image is BitmapImage) {
                     val bitmap = image.bitmap
-                    val rect = if (image.height / image.width < WEBTOON_THRESHOLD) {
+                    val ratio = if (image.height > image.width) {
+                        image.height / image.width
+                    } else {
+                        image.width / image.height
+                    }
+                    val rect = if (ratio < RATIO_THRESHOLD) {
                         val array = detectBorder(bitmap)
                         val minWidth = image.width * CROP_THRESHOLD
                         val minHeight = image.height * CROP_THRESHOLD

--- a/app/src/main/kotlin/com/hippo/ehviewer/image/Image.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/image/Image.kt
@@ -30,8 +30,8 @@ import coil3.imageLoader
 import coil3.request.CachePolicy
 import coil3.request.ErrorResult
 import coil3.request.SuccessResult
+import coil3.size.Dimension
 import coil3.size.Precision
-import coil3.size.Scale
 import com.hippo.ehviewer.Settings
 import com.hippo.ehviewer.coil.BitmapImageWithRect
 import com.hippo.ehviewer.coil.maybeCropBorder
@@ -73,15 +73,13 @@ class Image private constructor(image: CoilImage, private val src: AutoCloseable
     }
 
     companion object {
-        private val targetWidth = appCtx.resources.displayMetrics.widthPixels * 2
-        private val targetHeight = appCtx.resources.displayMetrics.heightPixels * 2
+        private val targetWidth = appCtx.resources.displayMetrics.widthPixels * 3
 
         private suspend fun Either<ByteBufferSource, UniFileSource>.decodeCoil(): CoilImage {
             val req = appCtx.imageRequest {
                 onLeft { data(it.source) }
                 onRight { data(it.source.uri) }
-                size(targetWidth, targetHeight)
-                scale(Scale.FILL)
+                size(Dimension(targetWidth), Dimension.Undefined)
                 precision(Precision.INEXACT)
                 maybeCropBorder(Settings.cropBorder.value)
                 memoryCachePolicy(CachePolicy.DISABLED)


### PR DESCRIPTION
And don't scale tall images (webtoons).