### PR TITLE
Improve spacing of gallery list card and dialog text

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/MainActivity.kt
@@ -97,6 +97,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
@@ -534,6 +535,7 @@ val LocalSideSheetState = compositionLocalOf<DrawerState2> { error("CompositionL
 val LocalDrawerLockHandle = compositionLocalOf<SnapshotStateList<Int>> { error("CompositionLocal LocalDrawerLockHandle not present!") }
 val LocalSnackBarHostState = compositionLocalOf<SnackbarHostState> { error("CompositionLocal LocalSnackBarHostState not present!") }
 val LocalSnackBarFabPadding = compositionLocalOf<State<Dp>> { error("CompositionLocal LocalSnackBarFabPadding not present!") }
+val LocalTextMeasurer = compositionLocalOf<TextMeasurer> { error("CompositionLocal LocalTextMeasurer not present!") }
 
 @Composable
 fun LockDrawer(value: Boolean) {

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/Theme.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/Theme.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.navigation.NavBackStackEntry
 import com.hippo.ehviewer.ui.theme.EhTheme
 import com.hippo.ehviewer.ui.tools.DialogState
@@ -42,6 +43,7 @@ inline fun ComponentActivity.setMD3Content(crossinline content: @Composable () -
             CompositionLocalProvider(
                 LocalDialogState provides dialogState,
                 LocalContentColor provides MaterialTheme.colorScheme.onBackground,
+                LocalTextMeasurer provides rememberTextMeasurer(),
             ) {
                 content()
             }

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/main/DownloadCard.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/main/DownloadCard.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
@@ -15,6 +17,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.ShapeDefaults
@@ -29,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -91,7 +95,7 @@ fun DownloadCard(
                 DownloadInfo.STATE_FINISH -> stringResource(R.string.download_state_finish)
                 else -> null // Chill, will be removed soon
             }
-            ConstraintLayout(modifier = Modifier.padding(8.dp, 4.dp).fillMaxSize()) {
+            ConstraintLayout(modifier = Modifier.padding(8.dp, 0.dp).fillMaxSize()) {
                 val (
                     titleRef, uploaderRef, ratingRef, categoryRef, actionsRef, stateTextRef,
                     progressBarRef, progressTextRef, speedRef,
@@ -119,12 +123,13 @@ fun DownloadCard(
                                 overflow = TextOverflow.Ellipsis,
                             )
                         }
+                        val ratingBasePadding = (LocalTextStyle.current.lineHeight.value.dp - dimensionResource(id = R.dimen.rating_size)) / 2
                         GalleryListCardRating(
                             rating = info.rating,
                             modifier = Modifier.constrainAs(ratingRef) {
                                 start.linkTo(parent.start)
                                 bottom.linkTo(categoryRef.top)
-                            },
+                            }.padding(top = ratingBasePadding - 2.dp, bottom = ratingBasePadding + 2.dp),
                         )
                         val categoryColor = EhUtils.getCategoryColor(info.category)
                         val categoryText = EhUtils.getCategory(info.category).uppercase()
@@ -133,7 +138,7 @@ fun DownloadCard(
                             modifier = Modifier.constrainAs(categoryRef) {
                                 start.linkTo(parent.start)
                                 bottom.linkTo(parent.bottom)
-                            }.clip(ShapeDefaults.Small).background(categoryColor).padding(vertical = 2.dp, horizontal = 8.dp),
+                            }.clip(ShapeDefaults.Small).background(categoryColor).padding(vertical = 1.dp, horizontal = 8.dp),
                             color = if (Settings.harmonizeCategoryColor) Color.Unspecified else EhUtils.categoryTextColor,
                             textAlign = TextAlign.Center,
                         )
@@ -173,12 +178,13 @@ fun DownloadCard(
                         )
                     }
                 }
+                val actionButtonSize = MaterialTheme.typography.labelLarge.lineHeight.value.dp * 2 + 2.dp
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.constrainAs(actionsRef) {
                         end.linkTo(parent.end)
                         bottom.linkTo(parent.bottom)
-                    },
+                    }.then(Modifier.size(actionButtonSize).offset(x = 8.dp))
                 ) {
                     val running = downloadState == DownloadInfo.STATE_WAIT || downloadState == DownloadInfo.STATE_DOWNLOAD
                     val icon = remember {
@@ -200,7 +206,7 @@ fun DownloadCard(
                     Text(
                         text = stateText,
                         modifier = Modifier.constrainAs(stateTextRef) {
-                            end.linkTo(parent.end, 16.dp)
+                            end.linkTo(parent.end)
                             bottom.linkTo(actionsRef.top)
                         },
                         style = MaterialTheme.typography.titleSmall,

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/main/DownloadCard.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/main/DownloadCard.kt
@@ -127,7 +127,7 @@ fun DownloadCard(
                         GalleryListCardRating(
                             rating = info.rating,
                             ratingSize = with(LocalDensity.current) {
-                                LocalTextStyle.current.fontSize.toDp()
+                                LocalTextStyle.current.fontSize.toDp() * 1.1f
                             },
                             modifier = Modifier.constrainAs(ratingRef) {
                                 start.linkTo(parent.start)

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/main/DownloadCard.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/main/DownloadCard.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -123,14 +123,16 @@ fun DownloadCard(
                                 overflow = TextOverflow.Ellipsis,
                             )
                         }
-                        val ratingBasePadding = (LocalTextStyle.current.lineHeight.value.dp - dimensionResource(id = R.dimen.rating_size)) / 2
-                        GalleryListCardRating(
-                            rating = info.rating,
-                            modifier = Modifier.constrainAs(ratingRef) {
-                                start.linkTo(parent.start)
-                                bottom.linkTo(categoryRef.top)
-                            }.padding(top = ratingBasePadding - 2.dp, bottom = ratingBasePadding + 2.dp),
-                        )
+                        with(LocalDensity.current) {
+                            GalleryListCardRating(
+                                rating = info.rating,
+                                ratingSize = LocalTextStyle.current.fontSize.toDp(),
+                                modifier = Modifier.constrainAs(ratingRef) {
+                                    start.linkTo(parent.start)
+                                    bottom.linkTo(categoryRef.top, margin = 4.dp)
+                                },
+                            )
+                        }
                         val categoryColor = EhUtils.getCategoryColor(info.category)
                         val categoryText = EhUtils.getCategory(info.category).uppercase()
                         Text(

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/main/DownloadCard.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/main/DownloadCard.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -44,6 +43,7 @@ import com.hippo.ehviewer.Settings
 import com.hippo.ehviewer.client.EhUtils
 import com.hippo.ehviewer.dao.DownloadInfo
 import com.hippo.ehviewer.download.DownloadManager
+import com.hippo.ehviewer.ui.LocalTextMeasurer
 import com.hippo.ehviewer.ui.tools.CrystalCard
 import com.hippo.ehviewer.ui.tools.GalleryListCardRating
 import com.hippo.ehviewer.util.FileUtils
@@ -185,10 +185,10 @@ fun DownloadCard(
 
                 // Make spacing consistent with gallery page
                 // The height of the action button should be 2 * height of Text composable + 1dp of vertical padding (2dp total)
-                val textMeasurer = rememberTextMeasurer()
-                val measuredHeight = with(LocalDensity.current) {
-                    textMeasurer.measure("", MaterialTheme.typography.labelLarge).size.height.toDp()
-                }
+                val textMeasurer = LocalTextMeasurer.current
+                val density = LocalDensity.current
+                val labelLarge = MaterialTheme.typography.labelLarge
+                val measuredHeight = remember(textMeasurer) { with(density) { textMeasurer.measure("", labelLarge).size.height.toDp() } }
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.constrainAs(actionsRef) {
@@ -196,8 +196,7 @@ fun DownloadCard(
                         bottom.linkTo(parent.bottom)
                     }.height(measuredHeight * 2 + 2.dp),
                 ) {
-                    val running =
-                        downloadState == DownloadInfo.STATE_WAIT || downloadState == DownloadInfo.STATE_DOWNLOAD
+                    val running = downloadState == DownloadInfo.STATE_WAIT || downloadState == DownloadInfo.STATE_DOWNLOAD
                     val icon = remember {
                         movableContentOf<Boolean> {
                             Icon(

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/main/DownloadCard.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/main/DownloadCard.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
@@ -33,12 +32,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.hippo.ehviewer.R
@@ -187,38 +185,35 @@ fun DownloadCard(
 
                 // Make spacing consistent with gallery page
                 // The height of the action button should be 2 * height of Text composable + 1dp of vertical padding (2dp total)
-                MeasureUnconstrainedViewHeight(
+                val textMeasurer = rememberTextMeasurer()
+                val measuredHeight = with(LocalDensity.current) {
+                    textMeasurer.measure("", MaterialTheme.typography.labelLarge).size.height.toDp()
+                }
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.constrainAs(actionsRef) {
-                        end.linkTo(parent.end)
+                        end.linkTo(parent.end, margin = (-8).dp)
                         bottom.linkTo(parent.bottom)
-                    },
-                    viewToMeasure = {
-                        Text(text = "", style = MaterialTheme.typography.labelLarge)
-                    },
-                ) { measuredHeight ->
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.height(measuredHeight * 2 + 2.dp).offset(x = 8.dp)
-                    ) {
-                        val running =
-                            downloadState == DownloadInfo.STATE_WAIT || downloadState == DownloadInfo.STATE_DOWNLOAD
-                        val icon = remember {
-                            movableContentOf<Boolean> {
-                                Icon(
-                                    imageVector = if (it) Icons.Default.Pause else Icons.Default.PlayArrow,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(measuredHeight * 1.25f),
-                                )
-                            }
+                    }.height(measuredHeight * 2 + 2.dp),
+                ) {
+                    val running =
+                        downloadState == DownloadInfo.STATE_WAIT || downloadState == DownloadInfo.STATE_DOWNLOAD
+                    val icon = remember {
+                        movableContentOf<Boolean> {
+                            Icon(
+                                imageVector = if (it) Icons.Default.Pause else Icons.Default.PlayArrow,
+                                contentDescription = null,
+                                modifier = Modifier.size(measuredHeight * 1.25f),
+                            )
                         }
-                        if (selectMode) {
-                            Box(modifier = Modifier.minimumInteractiveComponentSize()) {
-                                icon(running)
-                            }
-                        } else {
-                            IconButton(onClick = if (running) onStop else onStart) {
-                                icon(running)
-                            }
+                    }
+                    if (selectMode) {
+                        Box(modifier = Modifier.minimumInteractiveComponentSize()) {
+                            icon(running)
+                        }
+                    } else {
+                        IconButton(onClick = if (running) onStop else onStart) {
+                            icon(running)
                         }
                     }
                 }
@@ -234,26 +229,6 @@ fun DownloadCard(
                     )
                 }
             }
-        }
-    }
-}
-
-// https://stackoverflow.com/questions/70500071/is-it-possible-to-measure-string-width-to-properly-size-a-text-composable
-@Composable
-internal fun MeasureUnconstrainedViewHeight(
-    modifier: Modifier = Modifier,
-    viewToMeasure: @Composable () -> Unit,
-    content: @Composable (measuredWidth: Dp) -> Unit,
-) {
-    SubcomposeLayout(modifier = modifier) { constraints ->
-        val measuredHeight = subcompose("viewToMeasure", viewToMeasure)[0]
-            .measure(constraints).height.toDp()
-
-        val contentPlaceable = subcompose("content") {
-            content(measuredHeight)
-        }[0].measure(constraints)
-        layout(contentPlaceable.width, contentPlaceable.height) {
-            contentPlaceable.place(0, 0)
         }
     }
 }

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryInfo.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryInfo.kt
@@ -160,7 +160,7 @@ fun GalleryInfoListItem(
                         )
                     }
                     info.simpleLanguage?.let {
-                        Text(text = info.simpleLanguage.orEmpty())
+                        Text(text = it)
                     }
                     if (info.pages != 0 && showPages) {
                         Text(text = "${info.pages}P")

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryInfo.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryInfo.kt
@@ -174,6 +174,8 @@ fun GalleryInfoListItem(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.layoutId(favRef),
                 ) {
+                    // PlaceHolder to reserve minimum height
+                    Text(text = "")
                     if (isInFavScene) {
                         info.favoriteNote?.let {
                             Text(text = it, fontStyle = FontStyle.Italic)

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryInfo.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryInfo.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material3.Badge
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.ShapeDefaults
@@ -36,6 +37,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.BrushPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -43,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.ConstraintSet
 import arrow.core.Tuple7
+import com.hippo.ehviewer.R
 import com.hippo.ehviewer.Settings
 import com.hippo.ehviewer.client.EhUtils
 import com.hippo.ehviewer.client.data.GalleryInfo
@@ -110,7 +113,7 @@ fun GalleryInfoListItem(
                 modifier = Modifier.aspectRatio(DEFAULT_ASPECT).fillMaxSize(),
             )
         }
-        ConstraintLayout(modifier = Modifier.padding(8.dp, 4.dp).fillMaxSize(), constraintSet = constraintSet) {
+        ConstraintLayout(modifier = Modifier.padding(8.dp, 0.dp).fillMaxSize(), constraintSet = constraintSet) {
             val (titleRef, uploaderRef, ratingRef, categoryRef, postedRef, favRef, iconsRef) = ids
             Text(
                 text = EhUtils.getSuitableTitle(info),
@@ -128,15 +131,16 @@ fun GalleryInfoListItem(
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
+                val ratingBasePadding = (LocalTextStyle.current.lineHeight.value.dp - dimensionResource(id = R.dimen.rating_size)) / 2
                 GalleryListCardRating(
                     rating = info.rating,
-                    modifier = Modifier.layoutId(ratingRef),
+                    modifier = Modifier.layoutId(ratingRef).padding(top = ratingBasePadding - 2.dp, bottom = ratingBasePadding + 2.dp),
                 )
                 val categoryColor = EhUtils.getCategoryColor(info.category)
                 val categoryText = EhUtils.getCategory(info.category).uppercase()
                 Text(
                     text = categoryText,
-                    modifier = Modifier.layoutId(categoryRef).clip(ShapeDefaults.Small).background(categoryColor).padding(vertical = 2.dp, horizontal = 8.dp),
+                    modifier = Modifier.layoutId(categoryRef).clip(ShapeDefaults.Small).background(categoryColor).padding(vertical = 1.dp, horizontal = 8.dp),
                     color = if (Settings.harmonizeCategoryColor) Color.Unspecified else EhUtils.categoryTextColor,
                     textAlign = TextAlign.Center,
                 )
@@ -153,13 +157,15 @@ fun GalleryInfoListItem(
                             modifier = Modifier.size(16.dp),
                         )
                     }
-                    Text(text = info.simpleLanguage.orEmpty())
+                    if (info.simpleLanguage != null) {
+                        Text(text = info.simpleLanguage.orEmpty())
+                    }
                     if (info.pages != 0 && showPages) {
                         Text(text = "${info.pages}P")
                     }
                 }
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    horizontalArrangement = if (info.favoriteName != null) Arrangement.spacedBy(6.dp) else Arrangement.Start,
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.layoutId(favRef),
                 ) {
@@ -182,7 +188,7 @@ fun GalleryInfoListItem(
                 }
                 Text(
                     text = info.posted.orEmpty(),
-                    modifier = Modifier.layoutId(postedRef),
+                    modifier = Modifier.layoutId(postedRef).padding(vertical = 1.dp),
                 )
             }
         }

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryInfo.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryInfo.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.BrushPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.layoutId
-import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -45,7 +45,6 @@ import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.ConstraintSet
 import arrow.core.Tuple7
-import com.hippo.ehviewer.R
 import com.hippo.ehviewer.Settings
 import com.hippo.ehviewer.client.EhUtils
 import com.hippo.ehviewer.client.data.GalleryInfo
@@ -71,7 +70,7 @@ private val constraintSet = ConstraintSet {
     }
     constrain(ratingRef) {
         start.linkTo(parent.start)
-        bottom.linkTo(categoryRef.top)
+        bottom.linkTo(categoryRef.top, margin = 4.dp)
     }
     constrain(categoryRef) {
         start.linkTo(parent.start)
@@ -131,11 +130,13 @@ fun GalleryInfoListItem(
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
-                val ratingBasePadding = (LocalTextStyle.current.lineHeight.value.dp - dimensionResource(id = R.dimen.rating_size)) / 2
-                GalleryListCardRating(
-                    rating = info.rating,
-                    modifier = Modifier.layoutId(ratingRef).padding(top = ratingBasePadding - 2.dp, bottom = ratingBasePadding + 2.dp),
-                )
+                with(LocalDensity.current) {
+                    GalleryListCardRating(
+                        rating = info.rating,
+                        ratingSize = LocalTextStyle.current.fontSize.toDp(),
+                        modifier = Modifier.layoutId(ratingRef),
+                    )
+                }
                 val categoryColor = EhUtils.getCategoryColor(info.category)
                 val categoryText = EhUtils.getCategory(info.category).uppercase()
                 Text(

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryInfo.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryInfo.kt
@@ -66,10 +66,11 @@ private val constraintSet = ConstraintSet {
     }
     constrain(uploaderRef) {
         start.linkTo(parent.start)
-        bottom.linkTo(ratingRef.top)
+        bottom.linkTo(iconsRef.top)
     }
     constrain(ratingRef) {
         start.linkTo(parent.start)
+        top.linkTo(uploaderRef.bottom)
         bottom.linkTo(categoryRef.top, margin = 4.dp)
     }
     constrain(categoryRef) {
@@ -112,7 +113,7 @@ fun GalleryInfoListItem(
                 modifier = Modifier.aspectRatio(DEFAULT_ASPECT).fillMaxSize(),
             )
         }
-        ConstraintLayout(modifier = Modifier.padding(8.dp, 0.dp).fillMaxSize(), constraintSet = constraintSet) {
+        ConstraintLayout(modifier = Modifier.padding(horizontal = 8.dp).fillMaxSize(), constraintSet = constraintSet) {
             val (titleRef, uploaderRef, ratingRef, categoryRef, postedRef, favRef, iconsRef) = ids
             Text(
                 text = EhUtils.getSuitableTitle(info),
@@ -130,13 +131,13 @@ fun GalleryInfoListItem(
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
-                with(LocalDensity.current) {
-                    GalleryListCardRating(
-                        rating = info.rating,
-                        ratingSize = LocalTextStyle.current.fontSize.toDp(),
-                        modifier = Modifier.layoutId(ratingRef),
-                    )
-                }
+                GalleryListCardRating(
+                    rating = info.rating,
+                    ratingSize = with(LocalDensity.current) {
+                        LocalTextStyle.current.fontSize.toDp()
+                    },
+                    modifier = Modifier.layoutId(ratingRef),
+                )
                 val categoryColor = EhUtils.getCategoryColor(info.category)
                 val categoryText = EhUtils.getCategory(info.category).uppercase()
                 Text(
@@ -158,7 +159,7 @@ fun GalleryInfoListItem(
                             modifier = Modifier.size(16.dp),
                         )
                     }
-                    if (info.simpleLanguage != null) {
+                    info.simpleLanguage?.let {
                         Text(text = info.simpleLanguage.orEmpty())
                     }
                     if (info.pages != 0 && showPages) {

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryInfo.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryInfo.kt
@@ -123,6 +123,9 @@ fun GalleryInfoListItem(
                 style = MaterialTheme.typography.titleSmall,
             )
             ProvideTextStyle(MaterialTheme.typography.labelLarge) {
+                val localFontSize = with(LocalDensity.current) {
+                    LocalTextStyle.current.fontSize.toDp()
+                }
                 info.uploader?.let {
                     Text(
                         text = it,
@@ -133,9 +136,7 @@ fun GalleryInfoListItem(
                 }
                 GalleryListCardRating(
                     rating = info.rating,
-                    ratingSize = with(LocalDensity.current) {
-                        LocalTextStyle.current.fontSize.toDp()
-                    },
+                    ratingSize = localFontSize * 1.1f,
                     modifier = Modifier.layoutId(ratingRef),
                 )
                 val categoryColor = EhUtils.getCategoryColor(info.category)
@@ -156,7 +157,7 @@ fun GalleryInfoListItem(
                         Icon(
                             Icons.Default.Download,
                             contentDescription = null,
-                            modifier = Modifier.size(16.dp),
+                            modifier = Modifier.size(localFontSize),
                         )
                     }
                     info.simpleLanguage?.let {
@@ -182,7 +183,7 @@ fun GalleryInfoListItem(
                             Icon(
                                 Icons.Default.Favorite,
                                 contentDescription = null,
-                                modifier = Modifier.size(16.dp),
+                                modifier = Modifier.size(localFontSize),
                             )
                             Text(text = info.favoriteName.orEmpty())
                         }

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryInfo.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryInfo.kt
@@ -152,6 +152,8 @@ fun GalleryInfoListItem(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.layoutId(iconsRef),
                 ) {
+                    // PlaceHolder to reserve minimum height
+                    Text(text = "")
                     val download by DownloadManager.collectContainDownloadInfo(info.gid)
                     if (download) {
                         Icon(
@@ -168,15 +170,14 @@ fun GalleryInfoListItem(
                     }
                 }
                 Row(
-                    horizontalArrangement = if (info.favoriteName != null) Arrangement.spacedBy(6.dp) else Arrangement.Start,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.layoutId(favRef),
                 ) {
                     if (isInFavScene) {
-                        Text(
-                            text = info.favoriteNote.orEmpty(),
-                            fontStyle = FontStyle.Italic,
-                        )
+                        info.favoriteNote?.let {
+                            Text(text = it, fontStyle = FontStyle.Italic)
+                        }
                     } else {
                         val showFav by FavouriteStatusRouter.collectAsState(info) { it != NOT_FAVORITED }
                         if (showFav) {
@@ -185,7 +186,9 @@ fun GalleryInfoListItem(
                                 contentDescription = null,
                                 modifier = Modifier.size(localFontSize),
                             )
-                            Text(text = info.favoriteName.orEmpty())
+                            info.favoriteName?.let {
+                                Text(text = it)
+                            }
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/tools/RatingWidget.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/tools/RatingWidget.kt
@@ -126,7 +126,7 @@ fun GalleryListCardRating(rating: Float, ratingSize: Dp, modifier: Modifier = Mo
     MetaRatingWidgetReuse(
         rating = rating,
         ratingSize = ratingSize,
-        ratingInterval = ratingSize / 12f,
+        ratingInterval = ratingSize / 16f,
         modifier = modifier,
     )
 }

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/tools/RatingWidget.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/tools/RatingWidget.kt
@@ -17,10 +17,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.hippo.ehviewer.R
 import kotlin.math.roundToInt
 
 private val colorYellow800 = Color(0xfff9a825)
@@ -124,11 +122,11 @@ fun MetaRatingWidget(rating: Float, ratingSize: Dp, ratingInterval: Dp, modifier
 }
 
 @Composable
-fun GalleryListCardRating(rating: Float, modifier: Modifier = Modifier) {
+fun GalleryListCardRating(rating: Float, ratingSize: Dp, modifier: Modifier = Modifier) {
     MetaRatingWidgetReuse(
         rating = rating,
-        ratingSize = dimensionResource(id = R.dimen.rating_size),
-        ratingInterval = dimensionResource(id = R.dimen.rating_interval),
+        ratingSize = ratingSize,
+        ratingInterval = ratingSize / 12f,
         modifier = modifier,
     )
 }

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -24,10 +24,6 @@
 
     <dimen name="strip_item_padding">8dp</dimen>
 
-    <!-- RatingView -->
-    <dimen name="rating_size">16dp</dimen>
-    <dimen name="rating_interval">1dp</dimen>
-
     <dimen name="gallery_list_interval">12dp</dimen>
     <dimen name="gallery_list_margin_h">12dp</dimen>
     <dimen name="gallery_list_margin_v">4dp</dimen>


### PR DESCRIPTION
优化画廊及下载页面卡片内容的对齐
上：修改前
下：修改后

![Screenshot_20240416_203116_EhViewer Debug](https://github.com/FooIbar/EhViewer/assets/13722982/4133ea30-1e7a-4129-9bef-e1edab427c58)
![Screenshot_20240416_203136_EhViewer Debug](https://github.com/FooIbar/EhViewer/assets/13722982/54eee2eb-2d5d-43c3-a656-42ce6a62e01d)
