### PR TITLE
Refactor `UniFile.fromUri` for tree uri

### DIFF
--- a/app/src/main/kotlin/com/hippo/unifile/DocumentsContractApi21.kt
+++ b/app/src/main/kotlin/com/hippo/unifile/DocumentsContractApi21.kt
@@ -34,14 +34,9 @@ object DocumentsContractApi21 {
     fun createDirectory(self: Uri, displayName: String) = createFile(self, DocumentsContract.Document.MIME_TYPE_DIR, displayName)
 
     fun prepareTreeUri(treeUri: Uri): Uri {
-        val documentId = if (treeUri.pathSegments.size == 2) {
-            DocumentsContract.getTreeDocumentId(treeUri)
-        } else {
-            DocumentsContract.getDocumentId(treeUri)
-        }
         return DocumentsContract.buildDocumentUriUsingTree(
             treeUri,
-            documentId,
+            DocumentsContract.getTreeDocumentId(treeUri),
         )
     }
 
@@ -54,7 +49,7 @@ object DocumentsContractApi21 {
 
     fun listFiles(self: Uri) = sequence {
         val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(self, DocumentsContract.getDocumentId(self))
-        resolver.query(childrenUri, projection, null, null, null, null)?.use {
+        resolver.query(childrenUri, projection, null, null, null)?.use {
             while (it.moveToNext()) {
                 val documentId = it.getString(0)
                 val documentUri = DocumentsContract.buildDocumentUriUsingTree(self, documentId)

--- a/app/src/main/kotlin/com/hippo/unifile/RawFile.kt
+++ b/app/src/main/kotlin/com/hippo/unifile/RawFile.kt
@@ -20,7 +20,6 @@ import android.os.ParcelFileDescriptor
 import android.os.ParcelFileDescriptor.open
 import android.os.ParcelFileDescriptor.parseMode
 import android.webkit.MimeTypeMap
-import eu.kanade.tachiyomi.util.system.logcat
 import java.io.File
 import java.util.Locale
 
@@ -30,7 +29,6 @@ class RawFile(private val parent: RawFile?, private var file: File) : UniFile() 
     private val allChildren by lazy {
         val current = this
         cachePresent = true
-        logcat { "Directory lookup cache created for $name" }
         mutableListOf<RawFile>().apply {
             val fs = file.listFiles()?.map { RawFile(current, it) }
             if (fs != null) addAll(fs)

--- a/app/src/main/kotlin/com/hippo/unifile/UniFile.kt
+++ b/app/src/main/kotlin/com/hippo/unifile/UniFile.kt
@@ -220,17 +220,18 @@ sealed class UniFile {
     companion object {
         fun fromFile(file: File) = RawFile(null, file)
 
-        private fun fromSingleUri(singleUri: Uri) = SingleDocumentFile(singleUri)
-
-        private fun fromTreeUri(treeUri: Uri) = TreeDocumentFile(null, DocumentsContractApi21.prepareTreeUri(treeUri))
-
-        private fun fromMediaUri(mediaUri: Uri) = MediaFile(mediaUri)
-
         fun fromUri(uri: Uri) = when {
             isFileUri(uri) -> fromFile(uri.toFile())
-            isTreeUri(uri) -> fromTreeUri(uri)
-            isDocumentUri(uri) -> fromSingleUri(uri)
-            isMediaUri(uri) -> fromMediaUri(uri)
+            isTreeUri(uri) -> {
+                if (isDocumentUri(uri)) {
+                    TreeDocumentFile(null, uri)
+                } else {
+                    TreeDocumentFile(null, DocumentsContractApi21.prepareTreeUri(uri))
+                }
+            }
+
+            isDocumentUri(uri) -> SingleDocumentFile(uri)
+            isMediaUri(uri) -> MediaFile(uri)
             else -> null
         }
 
@@ -238,9 +239,9 @@ sealed class UniFile {
 
         fun isDocumentUri(uri: Uri) = DocumentsContract.isDocumentUri(appCtx, uri)
 
-        fun isTreeUri(uri: Uri) = DocumentsContractCompat.isTreeUri(uri)
+        private fun isTreeUri(uri: Uri) = DocumentsContractCompat.isTreeUri(uri)
 
-        fun isMediaUri(uri: Uri) = null != MediaContract.getName(uri)
+        private fun isMediaUri(uri: Uri) = null != MediaContract.getName(uri)
 
         val Stub = fromFile(File(""))
     }


### PR DESCRIPTION
This reverts b39e244 ("Fix `UniFile.fromUri` for children of tree uri") and 3978abe ("Fix UniFile.fromUri() for 2 path segments tree uri").