### PR TITLE
Drop `Xjvm-default=all`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,7 +120,6 @@ android {
         freeCompilerArgs = listOf(
             // https://kotlinlang.org/docs/compiler-reference.html#progressive
             "-progressive",
-            "-Xjvm-default=all",
             "-Xcontext-receivers",
 
             "-opt-in=coil3.annotation.ExperimentalCoilApi",


### PR DESCRIPTION
We are not a library intended for Javaers nor do we have any Java code to interop so this is meaningless and safely to drop