### PR TITLE
Change `UniFile.renameTo` to return a new UniFile

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/coil/DownloadThumbInterceptor.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/coil/DownloadThumbInterceptor.kt
@@ -22,7 +22,7 @@ object DownloadThumbInterceptor : Interceptor {
                 val thumb = withIOContext {
                     val legacyThumb = downloadLocation / location / LEGACY_THUMB_FILE
                     if (legacyThumb.isFile) {
-                        legacyThumb.apply { renameTo(THUMB_FILE) }
+                        legacyThumb.renameTo(THUMB_FILE) ?: legacyThumb
                     } else {
                         downloadLocation / location / THUMB_FILE
                     }

--- a/app/src/main/kotlin/com/hippo/unifile/MediaFile.kt
+++ b/app/src/main/kotlin/com/hippo/unifile/MediaFile.kt
@@ -62,5 +62,5 @@ class MediaFile(override val uri: Uri) : UniFile {
 
     override fun findFirst(filter: (String) -> Boolean) = null
 
-    override fun renameTo(displayName: String) = false
+    override fun renameTo(displayName: String) = null
 }

--- a/app/src/main/kotlin/com/hippo/unifile/RawFile.kt
+++ b/app/src/main/kotlin/com/hippo/unifile/RawFile.kt
@@ -22,8 +22,7 @@ import android.os.ParcelFileDescriptor.parseMode
 import android.webkit.MimeTypeMap
 import java.io.File
 
-class RawFile(override val parent: RawFile?, private var file: File) : UniFile {
-
+class RawFile(override val parent: RawFile?, private val file: File) : UniFile {
     private var cachePresent = false
     private val allChildren by lazy {
         cachePresent = true
@@ -119,13 +118,13 @@ class RawFile(override val parent: RawFile?, private var file: File) : UniFile {
         allChildren.firstOrNull { filter(it.name) }
     }
 
-    override fun renameTo(displayName: String): Boolean {
+    override fun renameTo(displayName: String): UniFile? {
         val target = File(file.parentFile, displayName)
-        if (file.renameTo(target)) {
-            file = target
-            return true
+        return if (file.renameTo(target)) {
+            RawFile(parent, target)
+        } else {
+            null
         }
-        return false
     }
 
     override fun openFileDescriptor(mode: String): ParcelFileDescriptor = open(file, parseMode(mode))

--- a/app/src/main/kotlin/com/hippo/unifile/SingleDocumentFile.kt
+++ b/app/src/main/kotlin/com/hippo/unifile/SingleDocumentFile.kt
@@ -18,7 +18,6 @@ package com.hippo.unifile
 import android.net.Uri
 
 class SingleDocumentFile(override val uri: Uri) : UniFile {
-
     override fun createFile(displayName: String) = null
 
     override fun createDirectory(displayName: String) = null
@@ -55,5 +54,5 @@ class SingleDocumentFile(override val uri: Uri) : UniFile {
 
     override fun findFirst(filter: (String) -> Boolean) = null
 
-    override fun renameTo(displayName: String) = false
+    override fun renameTo(displayName: String) = null
 }

--- a/app/src/main/kotlin/com/hippo/unifile/UniFile.kt
+++ b/app/src/main/kotlin/com/hippo/unifile/UniFile.kt
@@ -25,7 +25,7 @@ import java.io.File
 import splitties.init.appCtx
 
 /**
- * In Android files can be accessed via [java.io.File] and [android.net.Uri].
+ * In Android files can be accessed via [File] and [Uri].
  * The UniFile is designed to emulate File interface for both File and Uri.
  */
 sealed interface UniFile {
@@ -50,7 +50,7 @@ sealed interface UniFile {
     /**
      * Return a Uri for the underlying document represented by this file. This
      * can be used with other platform APIs to manipulate or share the
-     * underlying content. You can use [.isTreeUri] to
+     * underlying content. You can use [isTreeUri] to
      * test if the returned Uri is backed by a
      * [android.provider.DocumentsProvider].
      *
@@ -218,18 +218,18 @@ sealed interface UniFile {
      *
      *
      * Some providers may need to create a new file to reflect the rename,
-     * potentially with a different MIME type, so [.getUri] and
-     * [.getType] may change to reflect the rename.
+     * potentially with a different MIME type, so [uri] and
+     * [type] may change to reflect the rename.
      *
      *
      * When renaming a directory, children previously enumerated through
-     * [.listFiles] may no longer be valid.
+     * [listFiles] may no longer be valid.
      *
      * @param displayName the new display name.
-     * @return true on success.
+     * @return the renamed file on success, or `null`.
      * @see android.provider.DocumentsContract.renameDocument
      */
-    fun renameTo(displayName: String): Boolean
+    fun renameTo(displayName: String): UniFile?
 
     companion object {
         fun fromFile(file: File) = RawFile(null, file)


### PR DESCRIPTION
So the lookup cache will be reconstructed.