### PR TITLE
Revert "Clarify message for no current torrents"

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/main/TorrentList.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/main/TorrentList.kt
@@ -18,19 +18,21 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.hippo.ehviewer.R
 import com.hippo.ehviewer.client.parser.Torrent
 import com.hippo.ehviewer.client.parser.format
 
 @Composable
 fun TorrentList(
-    title: String,
     items: List<Torrent>,
     onItemClick: (Torrent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val title = stringResource(R.string.torrents)
     Column(
         modifier = modifier.padding(vertical = 8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/GalleryDetailScreen.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/GalleryDetailScreen.kt
@@ -561,12 +561,11 @@ fun GalleryDetailScreen(args: GalleryDetailScreenArgs, navigator: DestinationsNa
                     )
                 },
             )
-            val torrentText = stringResource(R.string.torrents)
+            val torrentText = stringResource(R.string.torrent_count, galleryDetail.torrentCount)
             val permissionDenied = stringResource(R.string.permission_denied)
             val downloadTorrentFailed = stringResource(R.string.download_torrent_failure)
             val downloadTorrentStarted = stringResource(R.string.download_torrent_started)
             val noTorrents = stringResource(R.string.no_torrents)
-            val noCurrentTorrents = stringResource(R.string.no_current_torrents)
             val torrentResult = remember(galleryDetail) {
                 async(Dispatchers.IO, CoroutineStart.LAZY) {
                     EhEngine.getTorrentList(galleryDetail.torrentUrl!!, gid, token)
@@ -575,11 +574,10 @@ fun GalleryDetailScreen(args: GalleryDetailScreenArgs, navigator: DestinationsNa
             suspend fun showTorrentDialog() {
                 val torrentList = bgWork { torrentResult.await() }
                 if (torrentList.isEmpty()) {
-                    showSnackbar(noCurrentTorrents)
+                    showSnackbar(noTorrents)
                 } else {
                     val selected = showNoButton(false) {
                         TorrentList(
-                            title = torrentText,
                             items = torrentList,
                             onItemClick = { dismissWith(it) },
                         )

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -119,7 +119,6 @@
     <string name="rate_successfully">评分成功</string>
     <string name="rate_failed">评分失败</string>
     <string name="no_torrents">没有种子</string>
-    <string name="no_current_torrents">没有当前版本画廊的种子</string>
     <string name="download_torrent_started">开始下载种子</string>
     <string name="download_torrent_failure">无法下载种子</string>
     <string name="torrents">种子</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,7 +159,6 @@
     <string name="rate_successfully">Rate successfully</string>
     <string name="rate_failed">Rate failed</string>
     <string name="no_torrents">No torrents</string>
-    <string name="no_current_torrents">No torrents for the current version of the gallery</string>
     <string name="download_torrent_started">Torrent download started</string>
     <string name="download_torrent_failure">Failed to download torrent</string>
     <string name="torrents">Torrents</string>


### PR DESCRIPTION
This reverts commit 49d4ae07

Reason for revert: We list outdated torrents as well after torrent dialog overhaul.