### PR TITLE
Revert "Update dependency sh.calvin.reorderable:reorderable to v2.0.4"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -97,7 +97,7 @@ okio-jvm = { module = "com.squareup.okio:okio-jvm", version.ref = "okio" }
 
 photoview = "com.github.chrisbanes:PhotoView:2.3.0"
 
-reorderable = "sh.calvin.reorderable:reorderable:2.0.4"
+reorderable = "sh.calvin.reorderable:reorderable:2.0.3"
 
 serialization-cbor = { module = "org.jetbrains.kotlinx:kotlinx-serialization-cbor", version.ref = "kotlinx-serialization" }
 serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }


### PR DESCRIPTION
This reverts commit 4cea8d0090b0817299954b1ef906f46252baf6c8.

Reason for revert: The item being dragged becomes invisible.