### PR TITLE
Revert "Update dependency com.android.application to v8.5.0-beta01"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 aboutlibraries = "11.1.4"
 accompanist = "0.34.0"
-agp = "8.5.0-beta01"
+agp = "8.5.0-alpha08"
 androidx-activity = "1.9.0"
 androidx-appcompat = "1.7.0-beta01"
 androidx-biometric = "1.2.0-alpha05"


### PR DESCRIPTION
Reverts FooIbar/EhViewer#1175

Reason for revert: Incompatible with canary AS