### PR TITLE
Workaround for displaying extremely long images

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/EhApplication.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/EhApplication.kt
@@ -59,6 +59,7 @@ import com.hippo.ehviewer.util.AppConfig
 import com.hippo.ehviewer.util.Crash
 import com.hippo.ehviewer.util.FavouriteStatusRouter
 import com.hippo.ehviewer.util.FileUtils
+import com.hippo.ehviewer.util.isAtLeastO
 import com.hippo.ehviewer.util.isAtLeastP
 import com.hippo.ehviewer.util.isAtLeastS
 import eu.kanade.tachiyomi.util.lang.launchIO
@@ -171,8 +172,10 @@ class EhApplication :
             add(KtorNetworkFetcherFactory { ktorClient })
             add(MergeInterceptor)
             add(DownloadThumbInterceptor)
+            if (isAtLeastO) {
+                add(HardwareBitmapInterceptor)
+            }
             add(CropBorderInterceptor)
-            add(HardwareBitmapInterceptor)
             if (isAtLeastP) {
                 add(AnimatedImageDecoder.Factory(false))
             } else {

--- a/app/src/main/kotlin/com/hippo/ehviewer/Settings.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/Settings.kt
@@ -141,6 +141,7 @@ object Settings : DataStorePreferences(null) {
     var readCacheSize by intPref("read_cache_size_2", 640)
     var launchPage by intPref("launch_page_2", 0)
     var commentThreshold by intPref("comment_threshold", -101)
+    var hardwareBitmapThreshold by intPref("hardware_bitmap_threshold", 16384)
     var forceEhThumb by boolPref("force_eh_thumb", false)
     var showComments by boolPref("show_gallery_comments", true)
     var requestNews by boolPref("request_news", false).observed { updateWhenRequestNewsChanges() }

--- a/app/src/main/kotlin/com/hippo/ehviewer/coil/CropBorderInterceptor.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/coil/CropBorderInterceptor.kt
@@ -1,20 +1,16 @@
 package com.hippo.ehviewer.coil
 
-import android.graphics.Bitmap
 import androidx.compose.ui.unit.IntRect
 import coil3.BitmapImage
 import coil3.Extras
 import coil3.Image
-import coil3.asCoilImage
 import coil3.getExtra
 import coil3.intercept.Interceptor
 import coil3.intercept.Interceptor.Chain
 import coil3.request.ImageRequest
 import coil3.request.ImageResult
 import coil3.request.SuccessResult
-import coil3.request.allowHardware
 import com.hippo.ehviewer.image.detectBorder
-import com.hippo.ehviewer.util.isAtLeastO
 
 private const val CROP_THRESHOLD = 0.75f
 private const val RATIO_THRESHOLD = 2
@@ -30,59 +26,33 @@ val ImageRequest.maybeCropBorder: Boolean
 
 class BitmapImageWithRect(
     val rect: IntRect,
-    val image: Image,
+    val image: BitmapImage,
 ) : Image by image
 
 object CropBorderInterceptor : Interceptor {
     override suspend fun intercept(chain: Chain): ImageResult {
-        val req = chain.request
-        if (req.maybeCropBorder) {
-            val hw = req.allowHardware && isAtLeastO
-            val result = if (hw) {
-                val nonHw = req.newBuilder().allowHardware(false).build()
-                chain.withRequest(nonHw).proceed()
-            } else {
-                chain.proceed()
-            }
-            if (result is SuccessResult) {
-                val image = result.image
-                if (image is BitmapImage) {
-                    val bitmap = image.bitmap
-                    val ratio = if (image.height > image.width) {
-                        image.height / image.width
-                    } else {
-                        image.width / image.height
+        val result = chain.proceed()
+        if (chain.request.maybeCropBorder && result is SuccessResult) {
+            val image = result.image
+            if (image is BitmapImage) {
+                val bitmap = image.bitmap
+                val ratio = if (image.height > image.width) {
+                    image.height / image.width
+                } else {
+                    image.width / image.height
+                }
+                if (ratio < RATIO_THRESHOLD) {
+                    val array = detectBorder(bitmap)
+                    val minWidth = image.width * CROP_THRESHOLD
+                    val minHeight = image.height * CROP_THRESHOLD
+                    val rect = IntRect(array[0], array[1], array[2], array[3])
+                    if (rect.width > minWidth && rect.height > minHeight) {
+                        val new = BitmapImageWithRect(rect, image)
+                        return result.copy(image = new, request = result.request, dataSource = result.dataSource)
                     }
-                    val rect = if (ratio < RATIO_THRESHOLD) {
-                        val array = detectBorder(bitmap)
-                        val minWidth = image.width * CROP_THRESHOLD
-                        val minHeight = image.height * CROP_THRESHOLD
-                        IntRect(array[0], array[1], array[2], array[3]).takeIf {
-                            it.width > minWidth && it.height > minHeight
-                        }
-                    } else {
-                        null
-                    }
-                    val maybeHwImage = if (hw) {
-                        // Upload to Graphical Buffer to accelerate render
-                        // May fail if the image is too long
-                        bitmap.copy(Bitmap.Config.HARDWARE, false)?.run {
-                            bitmap.recycle()
-                            asCoilImage()
-                        } ?: image
-                    } else {
-                        image
-                    }
-                    val new = if (rect != null) {
-                        BitmapImageWithRect(rect, maybeHwImage)
-                    } else {
-                        maybeHwImage
-                    }
-                    return result.copy(image = new, request = result.request, dataSource = result.dataSource)
                 }
             }
-            return result
         }
-        return chain.proceed()
+        return result
     }
 }

--- a/app/src/main/kotlin/com/hippo/ehviewer/coil/HardwareBitmapInterceptor.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/coil/HardwareBitmapInterceptor.kt
@@ -1,24 +1,37 @@
 package com.hippo.ehviewer.coil
 
+import android.graphics.Bitmap
+import android.os.Build
+import androidx.annotation.RequiresApi
+import coil3.BitmapImage
+import coil3.asCoilImage
 import coil3.intercept.Interceptor
 import coil3.intercept.Interceptor.Chain
-import coil3.request.ErrorResult
 import coil3.request.ImageResult
+import coil3.request.SuccessResult
 import coil3.request.allowHardware
 
-/**
- * Allocating hardware bitmaps may fail on extremely long images.
- *
- * Retry with [allowHardware] disabled.
- */
+@RequiresApi(Build.VERSION_CODES.O)
 object HardwareBitmapInterceptor : Interceptor {
     override suspend fun intercept(chain: Chain): ImageResult {
         val result = chain.proceed()
-        return if (chain.request.allowHardware && result is ErrorResult && result.throwable is OutOfMemoryError) {
-            val req = chain.request.newBuilder().allowHardware(false).build()
-            chain.withRequest(req).proceed()
-        } else {
-            result
+        if (!chain.request.allowHardware && result is SuccessResult) {
+            val image = when (val image = result.image) {
+                is BitmapImageWithRect -> image.image
+                is BitmapImage -> image
+                else -> return result
+            }
+            val bitmap = image.bitmap
+            // Large hardware bitmaps have rendering issues (e.g. crash, empty) on some devices.
+            // This is not ideal but I haven't figured out how to probe the threshold.
+            // All we know is that it's less than the maximum texture size.
+            if (maxOf(bitmap.width, bitmap.height) <= 8192) {
+                bitmap.copy(Bitmap.Config.HARDWARE, false)?.let {
+                    bitmap.recycle()
+                    return result.copy(image = it.asCoilImage(), request = result.request, dataSource = result.dataSource)
+                }
+            }
         }
+        return result
     }
 }

--- a/app/src/main/kotlin/com/hippo/ehviewer/coil/HardwareBitmapInterceptor.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/coil/HardwareBitmapInterceptor.kt
@@ -4,18 +4,31 @@ import android.graphics.Bitmap
 import android.os.Build
 import androidx.annotation.RequiresApi
 import coil3.BitmapImage
+import coil3.Extras
 import coil3.asCoilImage
+import coil3.getExtra
 import coil3.intercept.Interceptor
 import coil3.intercept.Interceptor.Chain
+import coil3.request.ImageRequest
 import coil3.request.ImageResult
 import coil3.request.SuccessResult
 import coil3.request.allowHardware
+
+private val hardwareThresholdKey = Extras.Key(default = 16384)
+
+fun ImageRequest.Builder.hardwareThreshold(size: Int) = apply {
+    extras[hardwareThresholdKey] = size
+}
+
+val ImageRequest.hardwareThreshold: Int
+    get() = getExtra(hardwareThresholdKey)
 
 @RequiresApi(Build.VERSION_CODES.O)
 object HardwareBitmapInterceptor : Interceptor {
     override suspend fun intercept(chain: Chain): ImageResult {
         val result = chain.proceed()
-        if (!chain.request.allowHardware && result is SuccessResult) {
+        val request = result.request
+        if (!request.allowHardware && result is SuccessResult) {
             val image = when (val image = result.image) {
                 is BitmapImageWithRect -> image.image
                 is BitmapImage -> image
@@ -25,10 +38,10 @@ object HardwareBitmapInterceptor : Interceptor {
             // Large hardware bitmaps have rendering issues (e.g. crash, empty) on some devices.
             // This is not ideal but I haven't figured out how to probe the threshold.
             // All we know is that it's less than the maximum texture size.
-            if (maxOf(bitmap.width, bitmap.height) <= 8192) {
+            if (maxOf(bitmap.width, bitmap.height) <= request.hardwareThreshold) {
                 bitmap.copy(Bitmap.Config.HARDWARE, false)?.let {
                     bitmap.recycle()
-                    return result.copy(image = it.asCoilImage(), request = result.request, dataSource = result.dataSource)
+                    return result.copy(image = it.asCoilImage(), request = request, dataSource = result.dataSource)
                 }
             }
         }

--- a/app/src/main/kotlin/com/hippo/ehviewer/image/Image.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/image/Image.kt
@@ -30,6 +30,7 @@ import coil3.imageLoader
 import coil3.request.CachePolicy
 import coil3.request.ErrorResult
 import coil3.request.SuccessResult
+import coil3.request.allowHardware
 import coil3.size.Dimension
 import coil3.size.Precision
 import com.hippo.ehviewer.Settings
@@ -81,6 +82,7 @@ class Image private constructor(image: CoilImage, private val src: AutoCloseable
                 onRight { data(it.source.uri) }
                 size(Dimension(targetWidth), Dimension.Undefined)
                 precision(Precision.INEXACT)
+                allowHardware(false)
                 maybeCropBorder(Settings.cropBorder.value)
                 memoryCachePolicy(CachePolicy.DISABLED)
             }

--- a/app/src/main/kotlin/com/hippo/ehviewer/image/Image.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/image/Image.kt
@@ -35,6 +35,7 @@ import coil3.size.Dimension
 import coil3.size.Precision
 import com.hippo.ehviewer.Settings
 import com.hippo.ehviewer.coil.BitmapImageWithRect
+import com.hippo.ehviewer.coil.hardwareThreshold
 import com.hippo.ehviewer.coil.maybeCropBorder
 import com.hippo.ehviewer.jni.isGif
 import com.hippo.ehviewer.jni.mmap
@@ -83,6 +84,7 @@ class Image private constructor(image: CoilImage, private val src: AutoCloseable
                 size(Dimension(targetWidth), Dimension.Undefined)
                 precision(Precision.INEXACT)
                 allowHardware(false)
+                hardwareThreshold(Settings.hardwareBitmapThreshold)
                 maybeCropBorder(Settings.cropBorder.value)
                 memoryCachePolicy(CachePolicy.DISABLED)
             }

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/settings/AdvancedScreen.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/settings/AdvancedScreen.kt
@@ -46,6 +46,7 @@ import com.hippo.ehviewer.util.Crash
 import com.hippo.ehviewer.util.ReadableTime
 import com.hippo.ehviewer.util.getAppLanguage
 import com.hippo.ehviewer.util.getLanguages
+import com.hippo.ehviewer.util.isAtLeastO
 import com.hippo.ehviewer.util.isAtLeastV
 import com.hippo.ehviewer.util.setAppLanguage
 import com.hippo.unifile.asUniFile
@@ -155,6 +156,15 @@ fun AdvancedScreen(navigator: DestinationsNavigator) {
                 useSelectedAsSummary = true,
                 entries = languages,
             )
+            if (isAtLeastO) {
+                IntSliderPreference(
+                    maxValue = 16384,
+                    step = 3,
+                    title = stringResource(id = R.string.settings_advanced_hardware_bitmap_threshold),
+                    summary = stringResource(id = R.string.settings_advanced_hardware_bitmap_threshold_summary),
+                    value = Settings::hardwareBitmapThreshold,
+                )
+            }
             SwitchPreference(
                 title = stringResource(id = R.string.preload_thumb_aggressively),
                 value = Settings::preloadThumbAggressively,

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -363,6 +363,8 @@
     <string name="settings_advanced_dump_logcat_to">已保存日志至 %s</string>
     <string name="settings_advanced_read_cache_size">阅读缓存大小</string>
     <string name="settings_advanced_app_language_title">App 界面语言</string>
+    <string name="settings_advanced_hardware_bitmap_threshold">硬件位图（性能更好）阈值</string>
+    <string name="settings_advanced_hardware_bitmap_threshold_summary">若长图无法加载请尝试减小此项</string>
     <string name="settings_advanced_export_data">导出数据</string>
     <string name="settings_advanced_export_data_summary">保存数据至外置存储器，例如下载列表，快速搜索列表</string>
     <string name="settings_advanced_export_data_to">已导出数据至 %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -406,6 +406,8 @@
     <string name="settings_advanced_dump_logcat_to">Logcat dumped to %s</string>
     <string name="settings_advanced_read_cache_size">Read cache size</string>
     <string name="settings_advanced_app_language_title">App language</string>
+    <string name="settings_advanced_hardware_bitmap_threshold">Hardware bitmap (better performance) threshold</string>
+    <string name="settings_advanced_hardware_bitmap_threshold_summary">Try decreasing this if long images fail to load</string>
     <string name="settings_advanced_export_data">Export data</string>
     <string name="settings_advanced_export_data_summary">Save data like download list, quick search list, to external storage</string>
     <string name="settings_advanced_export_data_to">Exported data to %s</string>


### PR DESCRIPTION
Large hardware bitmaps have rendering issues (e.g. crash, empty) on some devices.
This PR set the hardware bitmap threshold to 8192, which is not ideal but I haven't figured out how to probe that.
All we know is that it's less than the maximum texture size.

Thoughts?

Stack trace for the crash:
```
Abort message: 'glEGLImageTargetTexture2DOES error! GL_INVALID_OPERATION (0x502)'
    x0  0000000000000000  x1  0000000000004c64  x2  0000000000000006  x3  0000000000000008
    x4  4700000000000000  x5  4700000000000000  x6  4700000000000000  x7  00000000000080c7
    x8  0000000000000083  x9  061e566d31eb3741  x10 0000000000000000  x11 fffffffc7ffffbdf
    x12 0000000000000001  x13 0000000000000001  x14 ffffffffffffffff  x15 4700000000000000
    x16 000000746a3282a8  x17 000000746a247d48  x18 0000000000000010  x19 0000000000004c17
    x20 0000000000004c64  x21 000000746c6b48b8  x22 000000746c6b48a0  x23 000000746c6b496e
    x24 000000746c6b493f  x25 000000746c6b491f  x26 000000746c6b4954  x27 0000000000000502
    x28 000000746c6b493f  x29 00000073c7e0da20
    sp  00000073c7e0d9e0  lr  000000746a23b144  pc  000000746a23b16c

backtrace:
    #00 pc 000000000002216c  /system/lib64/libc.so (abort+116)
    #01 pc 0000000000008644  /system/lib64/liblog.so (__android_log_assert+296)
    #02 pc 00000000000e30b0  /system/lib64/libhwui.so (android::uirenderer::debug::GlesErrorCheckWrapper::assertNoErrors(char const*)+384)
```