### PR TITLE
Revert "Update dependency com.android.application to v8.6.0-alpha06"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 aboutlibraries = "11.2.1"
 accompanist = "0.34.0"
-agp = "8.6.0-alpha06"
+agp = "8.6.0-alpha05"
 androidx-activity = "1.9.0"
 androidx-appcompat = "1.7.0"
 androidx-biometric = "1.2.0-alpha05"


### PR DESCRIPTION
Reverts FooIbar/EhViewer#1325

Reason for revert: `java.lang.NoSuchMethodException: androidx.work.impl.WorkDatabase_Impl.<init> []`