### PR TITLE
Revert "Reuse the root download location UniFile object"

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/download/DownloadManager.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/download/DownloadManager.kt
@@ -809,16 +809,17 @@ object DownloadManager : OnSpiderListener, CoroutineScope {
     private fun comparator() = SortMode.from(Settings.downloadSortMode.value).comparator()
 }
 
-var downloadLocation = with(Settings) {
-    val uri = Uri.Builder().apply {
-        scheme(downloadScheme)
-        encodedAuthority(downloadAuthority)
-        encodedPath(downloadPath)
-        encodedQuery(downloadQuery)
-        encodedFragment(downloadFragment)
-    }.build()
-    uri.asUniFileOrNull() ?: AppConfig.defaultDownloadDir?.asUniFile() ?: UniFile.Stub
-}
+var downloadLocation: UniFile
+    get() = with(Settings) {
+        val uri = Uri.Builder().apply {
+            scheme(downloadScheme)
+            encodedAuthority(downloadAuthority)
+            encodedPath(downloadPath)
+            encodedQuery(downloadQuery)
+            encodedFragment(downloadFragment)
+        }.build()
+        uri.asUniFileOrNull() ?: AppConfig.defaultDownloadDir?.asUniFile() ?: UniFile.Stub
+    }
     set(value) = with(value.uri) {
         Settings.edit {
             downloadScheme = scheme
@@ -827,12 +828,7 @@ var downloadLocation = with(Settings) {
             downloadQuery = encodedQuery
             downloadFragment = encodedFragment
         }
-        field = value
     }
-
-fun invalidateDownloadDirCache() {
-    downloadLocation = downloadLocation.uri.asUniFile()
-}
 
 val DownloadInfo.downloadDir get() = dirname?.let { downloadLocation.findFile(it) }
 val DownloadInfo.archiveFile get() = downloadDir?.run { findFile("$gid.cbz") ?: findFile("$gid.zip") }

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/settings/DownloadScreen.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/settings/DownloadScreen.kt
@@ -37,7 +37,6 @@ import com.hippo.ehviewer.dao.DownloadInfo
 import com.hippo.ehviewer.download.DownloadManager
 import com.hippo.ehviewer.download.downloadDir
 import com.hippo.ehviewer.download.downloadLocation
-import com.hippo.ehviewer.download.invalidateDownloadDirCache
 import com.hippo.ehviewer.spider.COMIC_INFO_FILE
 import com.hippo.ehviewer.spider.SpiderDen
 import com.hippo.ehviewer.spider.SpiderQueen.Companion.SPIDER_INFO_FILENAME
@@ -216,8 +215,6 @@ fun DownloadScreen(navigator: DestinationsNavigator) = composing(navigator) {
                     }.getOrNull()
                 }
                 runSuspendCatching {
-                    // Rescan download directory for new files added by the user
-                    invalidateDownloadDirCache()
                     val result = downloadLocation.listFiles().parMapNotNull { getRestoreItem(it) }.also {
                         fillGalleryListByApi(it, EhUrl.referer)
                     }


### PR DESCRIPTION
Reason for revert: Caused OOM.

Resolve #1377 