### PR TITLE
Fix layout issue with comments that contain images

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/legacy/CoilImageGetter.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/legacy/CoilImageGetter.kt
@@ -7,23 +7,27 @@ import android.widget.TextView
 import coil3.asDrawable
 import coil3.imageLoader
 import coil3.request.crossfade
+import coil3.size.Size
 import com.hippo.ehviewer.ktbuilder.imageRequest
 
 class CoilImageGetter(
     private val textView: TextView,
 ) : Html.ImageGetter {
     override fun getDrawable(source: String) = object : DrawableWrapper(null) {}.apply {
-        textView.context.imageLoader.enqueue(
-            textView.context.imageRequest {
-                data(source)
-                crossfade(false)
-                target { drawable ->
-                    setDrawable(drawable.asDrawable(textView.resources))
-                    if (drawable is Animatable) drawable.start()
-                    setBounds(0, 0, intrinsicWidth, intrinsicHeight)
-                    textView.text = textView.text
-                }
-            },
-        )
+        with(textView.context) {
+            imageLoader.enqueue(
+                imageRequest {
+                    data(source)
+                    crossfade(false)
+                    size(Size.ORIGINAL)
+                    target { drawable ->
+                        setDrawable(drawable.asDrawable(resources))
+                        if (drawable is Animatable) drawable.start()
+                        setBounds(0, 0, intrinsicWidth, intrinsicHeight)
+                        textView.text = textView.text
+                    }
+                },
+            )
+        }
     }
 }


### PR DESCRIPTION
Seems it's a combined effect of shared element transitions and `Modifier.animateItem`.
I have no idea why this works.

Resolve #1468 