### PR TITLE
Use encoded token to avoid detection & revocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,6 @@ jobs:
           restore-keys: cmake-default-
 
       - name: Build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GithubToken }}
         run: ./gradlew assembleDefaultRelease
 
       - name: Upload ARM64
@@ -154,8 +152,6 @@ jobs:
           restore-keys: cmake-marshmallow-
 
       - name: Build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GithubToken }}
         run: ./gradlew assembleMarshmallowRelease
 
       - name: Upload ARM64

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -53,8 +53,6 @@ jobs:
           -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect"
 
       - name: Build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GithubToken }}
         run: ./gradlew assembleRelease
 
       - name: Rename Apks

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 import com.mikepenz.aboutlibraries.plugin.DuplicateMode.MERGE
 import com.mikepenz.aboutlibraries.plugin.DuplicateRule.GROUP
 import org.jetbrains.kotlin.compose.compiler.gradle.ComposeFeatureFlag
@@ -65,9 +64,6 @@ android {
     val chromeVersion = rootProject.layout.projectDirectory.file("chrome-for-testing/LATEST_RELEASE_STABLE").asFile
         .readText().substringBefore('.')
 
-    val githubToken = gradleLocalProperties(rootDir, providers)["GITHUB_TOKEN"] as? String
-        ?: System.getenv("GITHUB_TOKEN").orEmpty()
-
     defaultConfig {
         applicationId = "moe.tarsin.ehviewer"
         minSdk = 26
@@ -96,7 +92,6 @@ android {
         buildConfigField("long", "COMMIT_TIME", commitTime)
         buildConfigField("String", "REPO_NAME", "\"$repoName\"")
         buildConfigField("String", "CHROME_VERSION", "\"$chromeVersion\"")
-        buildConfigField("String", "GITHUB_TOKEN", "\"$githubToken\"")
         ndk {
             if (isRelease) {
                 abiFilters.addAll(supportedAbis)

--- a/app/src/main/kotlin/com/hippo/ehviewer/updater/AppUpdater.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/updater/AppUpdater.kt
@@ -13,6 +13,8 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.utils.io.jvm.javaio.toInputStream
 import java.io.File
 import java.util.zip.ZipInputStream
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.time.Duration.Companion.days
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -83,9 +85,12 @@ object AppUpdater {
         }
 }
 
+@OptIn(ExperimentalEncodingApi::class)
 private suspend inline fun ghStatement(url: String) = ktorClient.prepareGet(url) {
-    header("Authorization", "Bearer ${BuildConfig.GITHUB_TOKEN}")
+    header("Authorization", Base64.decode(GITHUB_TOKEN).decodeToString())
 }
+
+private const val GITHUB_TOKEN = "Z2l0aHViX3BhdF8xMUE0SDJBQ0kwNG9hY291VXNpYlN4X1FZcUg1V2hkUmpKVVNtZXpqM3ZleDlzUUxaQzh2U3JMNFZYUHhEY3dmaGNXTFFGSDZIM0wwdERZdXBy"
 
 data class Release(
     val version: String,


### PR DESCRIPTION
GitHub revoked the previous token cuz someone pushed the apk.