### PR TITLE
Refine reader

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/reader/GalleryPager.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/reader/GalleryPager.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -30,6 +29,8 @@ fun GalleryPager(
     pagerState: PagerState,
     lazyListState: LazyListState,
     pageLoader: PageLoader2,
+    showNavigationOverlay: Boolean,
+    onNavigationModeChange: () -> Unit,
     onSelectPage: (ReaderPage) -> Unit,
     onMenuRegionClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -46,16 +47,11 @@ fun GalleryPager(
     }
     val invertMode = if (isPagerType) pagerInvertMode else webtoonInvertMode
     var firstLaunch by remember { mutableStateOf(true) }
-    var showNavigationOverlay by remember {
-        val showOnStart = Settings.showNavigationOverlayNewUser.value || Settings.showNavigationOverlayOnStart.value
-        Settings.showNavigationOverlayNewUser.value = false
-        mutableStateOf(showOnStart)
-    }
     val regions = remember(navigation, invertMode) {
         if (firstLaunch) {
             firstLaunch = false
         } else {
-            showNavigationOverlay = true
+            onNavigationModeChange()
         }
         navigation.invertMode = TappingInvertMode.entries[invertMode]
         navigation.regions
@@ -68,7 +64,6 @@ fun GalleryPager(
             isVertical = type == VERTICAL,
             pageLoader = pageLoader,
             navigator = { navigator },
-            onClick = { showNavigationOverlay = false },
             onSelectPage = onSelectPage,
             onMenuRegionClick = onMenuRegionClick,
             contentPadding = contentPadding,
@@ -80,21 +75,11 @@ fun GalleryPager(
             withGaps = type == CONTINUOUS_VERTICAL,
             pageLoader = pageLoader,
             navigator = { navigator },
-            onClick = { showNavigationOverlay = false },
             onSelectPage = onSelectPage,
             onMenuRegionClick = onMenuRegionClick,
             contentPadding = contentPadding,
             modifier = modifier,
         )
-    }
-    LaunchedEffect(isPagerType) {
-        if (isPagerType) {
-            pagerState.interactionSource
-        } else {
-            lazyListState.interactionSource
-        }.interactions.collect {
-            showNavigationOverlay = false
-        }
     }
     NavigationOverlay(showNavigationOverlay, regions, modifier = Modifier.fillMaxSize())
 }

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/reader/SliderPagerDoubleSync.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/reader/SliderPagerDoubleSync.kt
@@ -1,6 +1,5 @@
 package com.hippo.ehviewer.ui.reader
 
-import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
@@ -31,11 +30,12 @@ class SliderPagerDoubleSync(
         sliderValue = index.coerceIn(1, pageLoader.size)
     }
 
+    fun reset() {
+        sliderFollowPager = true
+    }
+
     @Composable
-    fun Sync(webtoon: Boolean, appbarVisible: Boolean, onPageSelected: () -> Unit) {
-        val fling by lazyListState.interactionSource.collectIsDraggedAsState()
-        val pagerFling by pagerState.interactionSource.collectIsDraggedAsState()
-        if (fling || pagerFling || !appbarVisible) sliderFollowPager = true
+    fun Sync(webtoon: Boolean, onPageSelected: () -> Unit) {
         val currentIndexFlow = remember(webtoon) {
             val initialIndex = sliderValue - 1
             if (webtoon) {

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/reader/WebtoonViewer.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/reader/WebtoonViewer.kt
@@ -34,7 +34,6 @@ fun WebtoonViewer(
     withGaps: Boolean,
     pageLoader: PageLoader2,
     navigator: () -> NavigationRegions,
-    onClick: () -> Unit,
     onSelectPage: (ReaderPage) -> Unit,
     onMenuRegionClick: () -> Unit,
     contentPadding: PaddingValues,
@@ -56,10 +55,9 @@ fun WebtoonViewer(
         modifier = modifier.zoomable(
             state = zoomableState,
             onClick = {
-                onClick()
                 scope.launch {
                     with(lazyListState) {
-                        val size = lazyListState.layoutInfo.viewportSize
+                        val size = layoutInfo.viewportSize
                         val x = it.x / size.width
                         val y = it.y / size.height
                         when (navigator().getAction(x, y)) {


### PR DESCRIPTION
Fix navigation when switching from `WebtoonViewer` to `PagerViewer`.

Hide navigation overlay and reset slider to follow pager on click.