### PR TITLE
Fix account-based image limit parsing

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/client/EhEngine.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/client/EhEngine.kt
@@ -333,7 +333,7 @@ object EhEngine {
 
     suspend fun resetImageLimits() = ehRequest(EhUrl.URL_HOME) {
         formBody {
-            append("reset_imagelimit", "Reset Limit")
+            append("reset_imagelimit", "Reset Quota")
         }
     }.fetchUsingAsText(HomeParser::parseResetLimits)
 

--- a/app/src/main/rust/src/parser/home.rs
+++ b/app/src/main/rust/src/parser/home.rs
@@ -21,13 +21,17 @@ fn parse_limit(dom: &VDom, parser: &Parser) -> Option<Limits> {
         .as_tag()?
         .query_selector(parser, "strong")?;
     let vec: Vec<i32> = iter
-        .filter_map(|e| e.get(parser)?.inner_text(parser).parse::<i32>().ok())
+        .filter_map(|e| e.get(parser)?.inner_text(parser).replace(",", "").parse::<i32>().ok())
         .collect();
-    Some(Limits {
-        current: vec[0],
-        maximum: vec[1],
-        resetCost: vec[2],
-    })
+    if vec.len() == 3 {
+        Some(Limits {
+            current: vec[0],
+            maximum: vec[1],
+            resetCost: vec[2],
+        })
+    } else {
+        None
+    }
 }
 
 #[no_mangle]

--- a/app/src/main/rust/src/parser/home.rs
+++ b/app/src/main/rust/src/parser/home.rs
@@ -21,7 +21,13 @@ fn parse_limit(dom: &VDom, parser: &Parser) -> Option<Limits> {
         .as_tag()?
         .query_selector(parser, "strong")?;
     let vec: Vec<i32> = iter
-        .filter_map(|e| e.get(parser)?.inner_text(parser).replace(",", "").parse::<i32>().ok())
+        .filter_map(|e| {
+            e.get(parser)?
+                .inner_text(parser)
+                .replace(",", "")
+                .parse::<i32>()
+                .ok()
+        })
         .collect();
     if vec.len() == 3 {
         Some(Limits {


### PR DESCRIPTION
#1563 

We need to redesign the UI for IP-based ones.

> For IP-based quotas, it will no longer show what the limit is. This is intentional. It will however explicitly tell you on the home screen if your IP is currently restricted from using high-resolution images.

https://forums.e-hentai.org/index.php?showtopic=244935