### PR TITLE
Fix recent download label can't be set to `null`

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/Settings.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/Settings.kt
@@ -123,7 +123,7 @@ object Settings : DataStorePreferences(null) {
     val security = boolPref("require_unlock", false)
     val animateItems = boolPref("animate_items", true)
     val displayName = stringOrNullPref("display_name", null)
-    val recentDownloadLabel = stringOrNullPref("recent_download_label", "")
+    val recentDownloadLabel = stringOrNullPref("recent_download_label", null)
 
     var downloadScheme by stringOrNullPref("image_scheme", null)
     var downloadAuthority by stringOrNullPref("image_authority", null)
@@ -214,6 +214,9 @@ object Settings : DataStorePreferences(null) {
             edit {
                 if (KEY_SHOW_TAG_TRANSLATIONS !in prefs) showTagTranslations = true
             }
+        }
+        if (downloadFilterMode.value == DownloadsFilterMode.ARTIST.flag && recentDownloadLabel.value == null) {
+            recentDownloadLabel.value = ""
         }
     }
 


### PR DESCRIPTION
This reverts commit 822a461acd22e855f2c21c451c351ba14f421975.

https://github.com/FooIbar/EhViewer/issues/1555#issuecomment-2304116084