### PR TITLE
Pin Rust toolchain version to 1.81.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: 21
 
       - name: Install Rust Toolchain
-        run: rustup update && rustup target add armv7-linux-androideabi aarch64-linux-android x86_64-linux-android && rustup component add rustfmt clippy
+        run: rustup default 1.81.0 && rustup target add armv7-linux-androideabi aarch64-linux-android x86_64-linux-android && rustup component add rustfmt clippy
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -61,7 +61,7 @@ jobs:
           java-version: 21
 
       - name: Install Rust Toolchain
-        run: rustup update && rustup target add armv7-linux-androideabi aarch64-linux-android x86_64-linux-android && rustup component add rustfmt clippy
+        run: rustup default 1.81.0 && rustup target add armv7-linux-androideabi aarch64-linux-android x86_64-linux-android && rustup component add rustfmt clippy
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -129,7 +129,7 @@ jobs:
           java-version: 21
 
       - name: Install Rust Toolchain
-        run: rustup update && rustup target add armv7-linux-androideabi aarch64-linux-android x86_64-linux-android && rustup component add rustfmt clippy
+        run: rustup default 1.81.0 && rustup target add armv7-linux-androideabi aarch64-linux-android x86_64-linux-android && rustup component add rustfmt clippy
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
1.82.0 has a severe binary size regression (+36%)

```
    FILE SIZE        VM SIZE
 --------------  --------------
   +44%  +131Ki   +44%  +131Ki    .text
   +30% +10.7Ki   +30% +10.7Ki    .eh_frame
  +6.6% +2.82Ki  +6.6% +2.82Ki    .rodata
   +11% +2.58Ki   +11% +2.58Ki    .rela.dyn
   +16% +2.41Ki   +16% +2.41Ki    .data.rel.ro
  +190% +2.39Ki  +190% +2.39Ki    .gcc_except_table
   +22% +1.29Ki   +22% +1.29Ki    .eh_frame_hdr
   +16%    +176   +16%    +176    .rela.plt
   +12%    +168   +12%    +168    .dynsym
   +14%    +112   +14%    +112    .plt
   +14%     +56   +14%     +56    .got.plt
   +40%     +48   +40%     +48    .data
  +1.9%     +24  +1.9%     +24    .dynstr
   +14%     +16   +14%     +16    .gnu.version
  [ = ]       0  -0.3%      -8    .bss
  -3.6%     -16  -3.6%     -16    .dynamic
  [ = ]       0 -81.4% -2.36Ki    .relro_padding
   +36%  +154Ki   +35%  +152Ki    TOTAL
```