### PR TITLE
Propagate errors from `writeComicInfo` to callers

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/spider/SpiderDen.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/spider/SpiderDen.kt
@@ -352,19 +352,15 @@ class SpiderDen(val info: GalleryInfo) {
     suspend fun writeComicInfo(fetchMetadata: Boolean = true) {
         downloadDir?.run {
             resolve(COMIC_INFO_FILE).also {
-                runCatching {
-                    if (info !is GalleryDetail && fetchMetadata) {
-                        EhEngine.fillGalleryListByApi(listOf(info))
+                if (info !is GalleryDetail && fetchMetadata) {
+                    EhEngine.fillGalleryListByApi(listOf(info))
+                }
+                info.getComicInfo().apply {
+                    write(it)
+                    DownloadManager.getDownloadInfo(gid)?.let { downloadInfo ->
+                        downloadInfo.artistInfoList = DownloadArtist.from(gid, penciller.orEmpty())
+                        EhDB.putDownloadArtist(gid, downloadInfo.artistInfoList)
                     }
-                    info.getComicInfo().apply {
-                        write(it)
-                        DownloadManager.getDownloadInfo(gid)?.let { downloadInfo ->
-                            downloadInfo.artistInfoList = DownloadArtist.from(gid, penciller.orEmpty())
-                            EhDB.putDownloadArtist(gid, downloadInfo.artistInfoList)
-                        }
-                    }
-                }.onFailure {
-                    logcat(it)
                 }
             }
         }

--- a/app/src/main/kotlin/com/hippo/ehviewer/spider/SpiderQueen.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/spider/SpiderQueen.kt
@@ -224,7 +224,11 @@ class SpiderQueen private constructor(val galleryInfo: GalleryInfo) : CoroutineS
             }
             if (!spiderDen.postArchive()) {
                 if (mWorkerScope.isDownloadMode) {
-                    spiderDen.writeComicInfo()
+                    runCatching {
+                        spiderDen.writeComicInfo()
+                    }.onFailure {
+                        logcat(it)
+                    }
                 }
                 runCatching {
                     writeSpiderInfoToLocal()


### PR DESCRIPTION
Resolve #1895 