### PR TITLE
Don't use all caps for uploader names

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryDetail.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryDetail.kt
@@ -143,7 +143,7 @@ fun GalleryDetailHeaderCard(
                     )
                 },
             )
-            val uploaderText = info.uploader.orEmpty().uppercase()
+            val uploaderText = info.uploader.orEmpty()
             AssistChip(
                 onClick = onUploaderChipClick,
                 label = { Text(text = uploaderText, maxLines = 1) },


### PR DESCRIPTION
Uploader names are in UTF-8, `uppercase` may result in unexpected values
 in some locales.