### PR TITLE
Clean up renovate config

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ org.gradle.configuration-cache=true
 android.useAndroidX=true
 android.enableAppCompileTimeRClass=true
 android.r8.integratedResourceShrinking=true
-android.suppressUnsupportedCompileSdk=36
+ksp.version.check=false

--- a/renovate.json
+++ b/renovate.json
@@ -45,6 +45,12 @@
       "allowedVersions": "!/SNAPSHOT$/"
     },
     {
+      "matchDepNames": [
+        "com.mikepenz{:.}aboutlibraries*"
+      ],
+      "automerge": false
+    },
+    {
       "groupName": "AGP",
       "matchDepNames": [
         "com.android.application",
@@ -52,14 +58,6 @@
         "com.android.test"
       ],
       "allowedVersions": "/^[\\d.]+(-alpha\\d+)?$/"
-    },
-    {
-      "groupName": "Kotlin & KSP",
-      "matchSourceUrls": [
-        "https://github.com/JetBrains/kotlin",
-        "https://github.com/google/ksp"
-      ],
-      "recreateWhen": "never"
     },
     {
       "matchDepNames": [


### PR DESCRIPTION
KSP2 is no longer a compiler plugin so the Kotlin version doesn't matter