### PR TITLE
Update build scripts for Kotlin 2.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.mikepenz.aboutlibraries.plugin.DuplicateMode
 import com.mikepenz.aboutlibraries.plugin.DuplicateRule
 import java.util.regex.Pattern
+import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 
 val isRelease: Boolean
     get() = gradle.startParameter.taskNames.any { it.contains("Release") }
@@ -257,6 +258,7 @@ kotlin {
 
     // https://kotlinlang.org/docs/gradle-compiler-options.html#all-compiler-options
     compilerOptions {
+        jvmDefault = JvmDefaultMode.NO_COMPATIBILITY
         progressiveMode = true
         optIn.addAll(
             "coil3.annotation.ExperimentalCoilApi",
@@ -280,7 +282,6 @@ kotlin {
         )
         freeCompilerArgs.addAll(
             "-Xcontext-receivers",
-            "-Xwhen-guards",
             "-Xsuppress-warning=CONTEXT_RECEIVERS_DEPRECATED",
             "-Xannotation-default-target=param-property",
         )

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -7,15 +7,6 @@ plugins {
 android {
     namespace = "com.ehviewer.baselineprofile"
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-
     defaultConfig {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -35,6 +26,10 @@ android {
             systemImageSource = "aosp-atd"
         }
     }
+}
+
+kotlin {
+    jvmToolchain(21)
 }
 
 baselineProfile {


### PR DESCRIPTION
- Don't generate compatibility bridges and `DefaultImpls` classes
- Remove when guards compiler option as it became stable
- Address deprecation of `kotlinOptions`