### PR TITLE
Revert "MetaState trigger refresh implicitly (#2350)"

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/client/data/FavListUrlBuilder.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/client/data/FavListUrlBuilder.kt
@@ -29,9 +29,6 @@ data class FavListUrlBuilder(
     var prev: String? = null,
     var next: String? = null,
 ) {
-    val isLocal
-        get() = favCat == FAV_CAT_LOCAL
-
     fun setIndex(index: String?, isNext: Boolean) {
         next = index.takeIf { isNext }
         prev = index.takeUnless { isNext }

--- a/app/src/main/kotlin/com/hippo/ehviewer/client/data/ListUrlBuilder.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/client/data/ListUrlBuilder.kt
@@ -51,17 +51,9 @@ data class ListUrlBuilder(
         range = 0
     }
 
-    fun withIndex(index: String, isNext: Boolean = true) = copy(
-        next = index.takeIf { isNext },
-        prev = index.takeUnless { isNext },
-        range = 0,
-    )
-
     fun setJumpTo(to: Int) {
         jumpTo = to.takeUnless { it == 0 }?.toString()
     }
-
-    fun withJumpTo(to: Int) = copy(jumpTo = to.takeUnless { it == 0 }?.toString())
 
     fun setRange(to: Int) {
         range = to
@@ -69,13 +61,6 @@ data class ListUrlBuilder(
         next = null
         jumpTo = null
     }
-
-    fun withRange(to: Int) = copy(
-        range = to,
-        prev = null,
-        next = null,
-        jumpTo = null,
-    )
 
     var keyword: String?
         get() = if (MODE_UPLOADER == mode) "uploader:$mKeyword" else mKeyword

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/GalleryListScreen.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/GalleryListScreen.kt
@@ -133,7 +133,6 @@ import eu.kanade.tachiyomi.util.lang.withUIContext
 import kotlin.math.roundToInt
 import kotlin.random.Random
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.flatMapLatest
 import moe.tarsin.coroutines.onEachLatest
 import moe.tarsin.coroutines.runSuspendCatching
 import moe.tarsin.launch
@@ -196,49 +195,47 @@ fun AnimatedVisibilityScope.GalleryListScreen(lub: ListUrlBuilder, navigator: De
     val searchBarHint by rememberUpdatedState(if (EhUtils.isExHentai) exHint else ehHint)
     val suitableTitle = getSuitableTitleForUrlBuilder(urlBuilder)
     val data = rememberInVM {
-        snapshotFlow { urlBuilder }.flatMapLatest { builder ->
-            Pager(PagingConfig(25)) {
-                object : PagingSource<String, BaseGalleryInfo>() {
-                    override fun getRefreshKey(state: PagingState<String, BaseGalleryInfo>): String? = null
-                    override suspend fun load(params: LoadParams<String>) = withIOContext {
-                        if (builder.mode == MODE_TOPLIST) {
-                            // TODO: Since we know total pages, let pager support jump
-                            val key = (params.key ?: builder.jumpTo)?.toInt() ?: 0
-                            val prev = (key - 1).takeIf { it > 0 }
-                            val next = (key + 1).takeIf { it < TOPLIST_PAGES }
-                            runSuspendCatching {
-                                builder.setJumpTo(key)
-                                EhEngine.getGalleryList(builder.build())
-                            }.foldToLoadResult { result ->
-                                LoadResult.Page(result.galleryInfoList, prev?.toString(), next?.toString())
-                            }
-                        } else {
-                            when (params) {
-                                is LoadParams.Prepend -> builder.setIndex(params.key, isNext = false)
-                                is LoadParams.Append -> builder.setIndex(params.key, isNext = true)
-                                is LoadParams.Refresh -> {
-                                    val key = params.key
-                                    if (key.isNullOrBlank()) {
-                                        if (builder.jumpTo != null) {
-                                            builder.next ?: builder.setIndex("2", true)
-                                        }
-                                    } else {
-                                        builder.setIndex(key, false)
+        Pager(PagingConfig(25)) {
+            object : PagingSource<String, BaseGalleryInfo>() {
+                override fun getRefreshKey(state: PagingState<String, BaseGalleryInfo>): String? = null
+                override suspend fun load(params: LoadParams<String>) = withIOContext {
+                    if (urlBuilder.mode == MODE_TOPLIST) {
+                        // TODO: Since we know total pages, let pager support jump
+                        val key = (params.key ?: urlBuilder.jumpTo)?.toInt() ?: 0
+                        val prev = (key - 1).takeIf { it > 0 }
+                        val next = (key + 1).takeIf { it < TOPLIST_PAGES }
+                        runSuspendCatching {
+                            urlBuilder.setJumpTo(key)
+                            EhEngine.getGalleryList(urlBuilder.build())
+                        }.foldToLoadResult { result ->
+                            LoadResult.Page(result.galleryInfoList, prev?.toString(), next?.toString())
+                        }
+                    } else {
+                        when (params) {
+                            is LoadParams.Prepend -> urlBuilder.setIndex(params.key, isNext = false)
+                            is LoadParams.Append -> urlBuilder.setIndex(params.key, isNext = true)
+                            is LoadParams.Refresh -> {
+                                val key = params.key
+                                if (key.isNullOrBlank()) {
+                                    if (urlBuilder.jumpTo != null) {
+                                        urlBuilder.next ?: urlBuilder.setIndex("2", true)
                                     }
+                                } else {
+                                    urlBuilder.setIndex(key, false)
                                 }
                             }
-                            runSuspendCatching {
-                                val url = builder.build()
-                                EhEngine.getGalleryList(url)
-                            }.foldToLoadResult { result ->
-                                builder.jumpTo = null
-                                LoadResult.Page(result.galleryInfoList, result.prev, result.next)
-                            }
+                        }
+                        runSuspendCatching {
+                            val url = urlBuilder.build()
+                            EhEngine.getGalleryList(url)
+                        }.foldToLoadResult { result ->
+                            urlBuilder.jumpTo = null
+                            LoadResult.Page(result.galleryInfoList, result.prev, result.next)
                         }
                     }
                 }
-            }.flow
-        }.cachedIn(viewModelScope)
+            }
+        }.flow.cachedIn(viewModelScope)
     }.collectAsLazyPagingItems()
     ReportDrawnWhen { data.loadState.refresh !is LoadState.Loading }
     FavouriteStatusRouter.Observe(data)
@@ -269,6 +266,7 @@ fun AnimatedVisibilityScope.GalleryListScreen(lub: ListUrlBuilder, navigator: De
                     modifier = Modifier.padding(horizontal = 4.dp).clip(CardDefaults.shape).clickable {
                         Settings.recentToplist = keyword
                         urlBuilder = ListUrlBuilder(MODE_TOPLIST, mKeyword = keyword)
+                        data.refresh()
                         launch { sheetState.close() }
                     },
                     headlineContent = {
@@ -419,7 +417,10 @@ fun AnimatedVisibilityScope.GalleryListScreen(lub: ListUrlBuilder, navigator: De
                                             }
                                             navigate(builder.asDst())
                                         } else {
-                                            urlBuilder = ListUrlBuilder(item).apply { language = languageFilter }
+                                            urlBuilder = ListUrlBuilder(item).apply {
+                                                language = languageFilter
+                                            }
+                                            data.refresh()
                                         }
                                         launch { sheetState.close() }
                                     },
@@ -510,6 +511,7 @@ fun AnimatedVisibilityScope.GalleryListScreen(lub: ListUrlBuilder, navigator: De
             }
             else -> {
                 urlBuilder = builder
+                data.refresh()
             }
         }
     }
@@ -594,7 +596,10 @@ fun AnimatedVisibilityScope.GalleryListScreen(lub: ListUrlBuilder, navigator: De
                 )
             },
             searchBarOffsetY = { searchBarOffsetY },
-            onRefresh = { urlBuilder = urlBuilder.withRange(0) },
+            onRefresh = {
+                urlBuilder.setRange(0)
+                data.refresh()
+            },
             onLoading = { searchBarOffsetY = 0 },
         )
     }
@@ -620,33 +625,37 @@ fun AnimatedVisibilityScope.GalleryListScreen(lub: ListUrlBuilder, navigator: De
     ) {
         if (urlBuilder.mode in arrayOf(MODE_NORMAL, MODE_UPLOADER, MODE_TAG)) {
             onClick(Icons.Default.Shuffle) {
-                urlBuilder = urlBuilder.withRange(Random.nextInt(100))
+                urlBuilder.setRange(Random.nextInt(100))
+                data.refresh()
             }
         }
         onClick(Icons.Default.Refresh) {
-            urlBuilder = urlBuilder.withRange(0)
+            urlBuilder.setRange(0)
+            data.refresh()
         }
         if (urlBuilder.mode != MODE_WHATS_HOT) {
             onClick(EhIcons.Default.GoTo) {
-                urlBuilder = if (isTopList) {
+                if (isTopList) {
                     val page = urlBuilder.jumpTo?.toIntOrNull() ?: 0
                     val hint = string(R.string.go_to_hint, page + 1, TOPLIST_PAGES)
                     val text = awaitInputText(title = gotoTitle, hint = hint, isNumber = true) { oriText ->
                         val goto = ensureNotNull(oriText.trim().toIntOrNull()) { invalidNum } - 1
                         ensure(goto in 0..<TOPLIST_PAGES) { outOfRange }
                     }.trim().toInt() - 1
-                    urlBuilder.withJumpTo(text)
+                    urlBuilder.setJumpTo(text)
                 } else {
                     val date = awaitSelectDate()
-                    urlBuilder.copy(jumpTo = date)
+                    urlBuilder.jumpTo = date
                 }
+                data.refresh()
             }
             onClick(Icons.AutoMirrored.Default.LastPage) {
-                urlBuilder = if (isTopList) {
-                    urlBuilder.withJumpTo(TOPLIST_PAGES - 1)
+                if (isTopList) {
+                    urlBuilder.setJumpTo(TOPLIST_PAGES - 1)
                 } else {
-                    urlBuilder.withIndex("1", false)
+                    urlBuilder.setIndex("1", false)
                 }
+                data.refresh()
             }
         }
     }


### PR DESCRIPTION
This reverts commit 277deace470c7d6ad30bc49931199e21f59fb777. 
Revert reason: `ListUrlBuilder` doesn't have a qualified `equals` semantics