### PR TITLE
Revert "Store pToken in `GalleryPreview` and refine parser"

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/client/data/GalleryPreview.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/client/data/GalleryPreview.kt
@@ -15,31 +15,26 @@
  */
 package com.hippo.ehviewer.client.data
 
-import com.hippo.ehviewer.client.getThumbKey
-import com.hippo.ehviewer.client.getV2PreviewKey
+import com.hippo.ehviewer.client.keyToUrl
 
 sealed interface GalleryPreview {
     val url: String
     val imageKey: String
     val position: Int
-    val pToken: String
 }
 
 data class V1GalleryPreview(
-    override val url: String,
+    override val imageKey: String,
     override val position: Int,
-    override val pToken: String,
 ) : GalleryPreview {
-    override val imageKey get() = getThumbKey(url)
+    override val url get() = keyToUrl(imageKey)
 }
 
 data class V2GalleryPreview(
     override val url: String,
+    override val imageKey: String,
     override val position: Int,
-    override val pToken: String,
     val offsetX: Int,
     val clipWidth: Int,
     val clipHeight: Int,
-) : GalleryPreview {
-    override val imageKey get() = getV2PreviewKey(url)
-}
+) : GalleryPreview

--- a/app/src/main/kotlin/com/hippo/ehviewer/coil/Extensions.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/coil/Extensions.kt
@@ -30,11 +30,10 @@ fun ImageRequest.Builder.ehUrl(info: GalleryInfo) = apply {
 // Load in original size so the memory cache can be reused for preload requests
 fun ImageRequest.Builder.ehPreview(preview: GalleryPreview) = apply {
     with(preview) {
-        val key = imageKey
         data(url)
         size(SizeResolver.ORIGINAL)
-        memoryCacheKey(key)
-        diskCacheKey(key)
+        memoryCacheKey(imageKey)
+        diskCacheKey(imageKey)
     }
 }
 

--- a/app/src/main/kotlin/com/hippo/ehviewer/legacy/SpiderInfoCompat.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/legacy/SpiderInfoCompat.kt
@@ -10,15 +10,15 @@ fun Path.readLegacySpiderInfo() = read {
     fun readInt() = read().toInt()
     fun readLong() = read().toLong()
 
-    read() // Skip version, we assert it's v2
-    read() // Skip startPage
+    repeat(2) { read() } // We assert that only info v2
     val gid = readLong()
     val token = read()
-    read() // Skip mode
-    read() // Skip previewPages
+    read()
+    val previewPages = readInt()
     val previewPerPage = readInt()
-    val pages = readInt()
-    SpiderInfo(gid, token, pages, previewPerPage = previewPerPage).apply {
+    val pages = read().toInt()
+    val pTokenMap = hashMapOf<Int, String>()
+    SpiderInfo(gid, token, pages, pTokenMap, previewPages, previewPerPage).apply {
         runCatching {
             while (true) {
                 val line = read()

--- a/app/src/main/kotlin/com/hippo/ehviewer/spider/SpiderInfo.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/spider/SpiderInfo.kt
@@ -27,6 +27,8 @@ class SpiderInfo(
 
     val pTokenMap: MutableMap<Int, String> = hashMapOf(),
 
+    var previewPages: Int = -1,
+
     var previewPerPage: Int = -1,
 )
 

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/GalleryDetailContent.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/GalleryDetailContent.kt
@@ -805,7 +805,7 @@ private fun GalleryDetail.collectPreviewItems() = rememberInVM(previewList) {
                     (up..end).filterNot { it in previewPagesMap }.map { it / pageSize }.toSet()
                         .parMap(concurrency = Settings.multiThreadDownload) { page ->
                             val url = EhUrl.getGalleryDetailUrl(gid, token, page, false)
-                            EhEngine.getPreviewList(url)
+                            EhEngine.getPreviewList(url).first
                         }.flattenForEach {
                             previewPagesMap[it.position] = it
                             if (Settings.preloadThumbAggressively) {


### PR DESCRIPTION
Reverts FooIbar/EhViewer#2380
Resolve #2389 
This breaks mpv gallery preview parse as well.