### PR TITLE
Optimize rust binary size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: 21
 
       - name: Install Rust Toolchain
-        run: rustup default nightly-2024-08-30 && rustup target add armv7-linux-androideabi aarch64-linux-android x86_64-linux-android && rustup component add rustfmt clippy
+        run: rustup target add armv7-linux-androideabi aarch64-linux-android x86_64-linux-android
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -61,7 +61,7 @@ jobs:
           java-version: 21
 
       - name: Install Rust Toolchain
-        run: rustup default nightly-2024-08-30 && rustup target add armv7-linux-androideabi aarch64-linux-android x86_64-linux-android && rustup component add rustfmt clippy
+        run: rustup target add armv7-linux-androideabi aarch64-linux-android x86_64-linux-android
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -79,7 +79,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: app/.cxx
-          key: cmake-default-${{ hashFiles('settings.gradle.kts', 'app/src/main/cpp/CMakeLists.txt', 'app/src/main/cpp/*.patch', 'app/src/main/rust/Cargo.lock') }}
+          key: cmake-default-${{ hashFiles('settings.gradle.kts', 'app/src/main/cpp/CMakeLists.txt', 'app/src/main/rust/Cargo.lock') }}
           restore-keys: cmake-default-
 
       - name: Build
@@ -129,7 +129,7 @@ jobs:
           java-version: 21
 
       - name: Install Rust Toolchain
-        run: rustup default nightly-2024-08-30 && rustup target add armv7-linux-androideabi aarch64-linux-android x86_64-linux-android && rustup component add rustfmt clippy
+        run: rustup target add armv7-linux-androideabi aarch64-linux-android x86_64-linux-android
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -147,7 +147,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: app/.cxx
-          key: cmake-marshmallow-${{ hashFiles('settings.gradle.kts', 'app/src/main/cpp/CMakeLists.txt', 'app/src/main/cpp/*.patch', 'app/src/main/rust/Cargo.lock') }}
+          key: cmake-marshmallow-${{ hashFiles('settings.gradle.kts', 'app/src/main/cpp/CMakeLists.txt', 'app/src/main/rust/Cargo.lock') }}
           restore-keys: cmake-marshmallow-
 
       - name: Build

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -28,7 +28,7 @@ jobs:
           java-version: 21
 
       - name: Install Rust Toolchain
-        run: rustup default nightly-2024-08-30 && rustup target add armv7-linux-androideabi aarch64-linux-android x86_64-linux-android
+        run: rustup target add armv7-linux-androideabi aarch64-linux-android x86_64-linux-android
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -117,13 +117,13 @@ FetchContent_Declare(
 )
 
 FetchContent_MakeAvailable(Corrosion)
-corrosion_import_crate(MANIFEST_PATH ../rust/Cargo.toml LOCKED)
+corrosion_import_crate(
+        MANIFEST_PATH ../rust/Cargo.toml
+        LOCKED
+        FEATURES $<IF:$<VERSION_GREATER_EQUAL:${ANDROID_NATIVE_API_LEVEL},26>,android-26,android>
+        FLAGS $<$<NOT:$<CONFIG:Debug>>:-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort>
+)
 corrosion_add_target_local_rustflags(ehviewer_rust "-Clink-args=-Wl,-z,max-page-size=16384")
-if (ANDROID_NATIVE_API_LEVEL GREATER_EQUAL 26)
-    corrosion_set_features(ehviewer_rust FEATURES android-26)
-else ()
-    corrosion_set_features(ehviewer_rust FEATURES android)
-endif ()
 
 # Build and link our app's native lib
 add_library(${PROJECT_NAME} SHARED archive.c gifutils.c hash.c natsort/strnatcmp.c)

--- a/app/src/main/rust/src/lib.rs
+++ b/app/src/main/rust/src/lib.rs
@@ -63,7 +63,7 @@ where
     let bytes: Bytes = id.into();
     let handle = node.find_node(parser, &mut |n| match n.as_tag() {
         None => false,
-        Some(tag) => tag.attributes().id().map_or(false, |x| x.eq(&bytes)),
+        Some(tag) => tag.attributes().id().is_some_and(|x| x.eq(&bytes)),
     })?;
     handle.get(parser)
 }
@@ -114,7 +114,7 @@ fn query_childs_first_match_attr<'a>(
     parser: &'a Parser,
     attr: &'a str,
 ) -> Option<&'a str> {
-    let selector = format!("[{}]", attr);
+    let selector = format!("[{attr}]");
     let mut iter = node.as_tag()?.query_selector(parser, &selector)?;
     get_node_handle_attr(&iter.next()?, parser, attr)
 }

--- a/app/src/main/rust/src/parser/archive.rs
+++ b/app/src/main/rust/src/parser/archive.rs
@@ -41,7 +41,7 @@ pub fn parse_archive_url(dom: &VDom, parser: &Parser, body: &str) -> Result<Opti
     let url = dom.get_element_by_id("continue").and_then(|node| {
         let tag = select_first(node.get(parser)?.as_tag()?, parser, "a")?;
         let href = get_tag_attr(tag, "href")?;
-        Some(format!("{}?start=1", href))
+        Some(format!("{href}?start=1"))
     });
     Ok(url)
 }

--- a/app/src/main/rust/src/parser/profile.rs
+++ b/app/src/main/rust/src/parser/profile.rs
@@ -33,7 +33,7 @@ pub fn parse_profile(dom: &VDom, parser: &Parser) -> Result<Profile> {
                     if src.starts_with("http") {
                         src.to_string()
                     } else {
-                        format!("{}{}", HOST_FORUMS, src)
+                        format!("{HOST_FORUMS}{src}")
                     }
                 })
             });

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2025-06-10"
+components = ["rustfmt", "clippy", "rust-src"]
+profile = "minimal"


### PR DESCRIPTION
* -10.3% vs nightly-2024-08-30 with backtrace
* +2.8% vs nightly-2024-08-30 without backtrace

I think a 2.8% increase is acceptable (compared to 30+% in #1763) as the cost of updating the toolchain.