### PR TITLE
Clean up rust code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 /.kotlin
 *.iml
 .idea
+.vscode
 /captures

--- a/app/src/main/rust/src/ffi/android.rs
+++ b/app/src/main/rust/src/ffi/android.rs
@@ -14,8 +14,6 @@ use jni_fn::jni_fn;
 use ndk::bitmap::{Bitmap, BitmapFormat};
 use std::ptr::slice_from_raw_parts;
 
-#[unsafe(no_mangle)]
-#[allow(non_snake_case)]
 #[jni_fn("com.hippo.ehviewer.image.ImageKt")]
 pub fn detectBorder(mut env: JNIEnv, _class: JClass, object: jobject) -> jintArray {
     jni_throwing(&mut env, |env| {
@@ -26,8 +24,6 @@ pub fn detectBorder(mut env: JNIEnv, _class: JClass, object: jobject) -> jintArr
     })
 }
 
-#[unsafe(no_mangle)]
-#[allow(non_snake_case)]
 #[jni_fn("com.hippo.ehviewer.image.ImageKt")]
 pub fn hasQrCode(mut env: JNIEnv, _class: JClass, object: jobject) -> jboolean {
     jni_throwing(&mut env, |env| {

--- a/app/src/main/rust/src/ffi/android_o.rs
+++ b/app/src/main/rust/src/ffi/android_o.rs
@@ -9,8 +9,6 @@ use jni::sys::{jint, jobject};
 use jni_fn::jni_fn;
 use ndk::hardware_buffer::{HardwareBuffer, HardwareBufferUsage};
 
-#[unsafe(no_mangle)]
-#[allow(non_snake_case)]
 #[jni_fn("com.hippo.ehviewer.image.ImageKt")]
 pub fn copyBitmapToAHB(mut env: JNIEnv, _: JClass, bm: jobject, ahb: jobject, x: jint, y: jint) {
     let ahb = unsafe { HardwareBuffer::from_jni(env.get_raw(), ahb) };

--- a/app/src/main/rust/src/ffi/jvm.rs
+++ b/app/src/main/rust/src/ffi/jvm.rs
@@ -23,8 +23,6 @@ use std::ptr::slice_from_raw_parts_mut;
 use std::str::from_utf8_unchecked;
 use tl::{ParserOptions, VDom};
 
-#[unsafe(no_mangle)]
-#[allow(non_snake_case)]
 #[jni_fn("com.hippo.ehviewer.client.parser.FavoritesParserKt")]
 pub fn parseFav(mut env: JNIEnv, _class: JClass, input: JByteBuffer, limit: jint) -> jint {
     parse_marshal_inplace(&mut env, input, limit, |dom, html| {
@@ -32,8 +30,6 @@ pub fn parseFav(mut env: JNIEnv, _class: JClass, input: JByteBuffer, limit: jint
     })
 }
 
-#[unsafe(no_mangle)]
-#[allow(non_snake_case)]
 #[jni_fn("com.hippo.ehviewer.client.parser.HomeParserKt")]
 pub fn parseLimit(mut env: JNIEnv, _class: JClass, input: JByteBuffer, limit: jint) -> jint {
     parse_marshal_inplace(&mut env, input, limit, |dom, _| {
@@ -41,8 +37,6 @@ pub fn parseLimit(mut env: JNIEnv, _class: JClass, input: JByteBuffer, limit: ji
     })
 }
 
-#[unsafe(no_mangle)]
-#[allow(non_snake_case)]
 #[jni_fn("com.hippo.ehviewer.client.parser.GalleryListParserKt")]
 pub fn parseGalleryInfoList(mut env: JNIEnv, _: JClass, buffer: JByteBuffer, limit: jint) -> jint {
     parse_marshal_inplace(&mut env, buffer, limit, |dom, str| {
@@ -50,8 +44,6 @@ pub fn parseGalleryInfoList(mut env: JNIEnv, _: JClass, buffer: JByteBuffer, lim
     })
 }
 
-#[unsafe(no_mangle)]
-#[allow(non_snake_case)]
 #[jni_fn("com.hippo.ehviewer.client.parser.GalleryDetailParser")]
 pub fn parseGalleryDetail(mut env: JNIEnv, _: JClass, buffer: JByteBuffer, limit: jint) -> jint {
     let options = ParserOptions::default().track_ids();
@@ -60,8 +52,6 @@ pub fn parseGalleryDetail(mut env: JNIEnv, _: JClass, buffer: JByteBuffer, limit
     })
 }
 
-#[unsafe(no_mangle)]
-#[allow(non_snake_case)]
 #[jni_fn("com.hippo.ehviewer.client.parser.EventPaneParser")]
 pub fn parseEventPane(mut env: JNIEnv, _class: JClass, input: JByteBuffer, limit: jint) -> jint {
     parse_marshal_inplace(&mut env, input, limit, |dom, _| {
@@ -69,8 +59,6 @@ pub fn parseEventPane(mut env: JNIEnv, _class: JClass, input: JByteBuffer, limit
     })
 }
 
-#[unsafe(no_mangle)]
-#[allow(non_snake_case)]
 #[jni_fn("com.hippo.ehviewer.client.parser.TorrentParserKt")]
 pub fn parseTorrent(mut env: JNIEnv, _class: JClass, buffer: JByteBuffer, limit: jint) -> jint {
     parse_marshal_inplace(&mut env, buffer, limit, |dom, _| {
@@ -78,15 +66,11 @@ pub fn parseTorrent(mut env: JNIEnv, _class: JClass, buffer: JByteBuffer, limit:
     })
 }
 
-#[unsafe(no_mangle)]
-#[allow(non_snake_case)]
 #[jni_fn("com.hippo.ehviewer.client.parser.UserConfigParser")]
 pub fn parseFavCat(mut env: JNIEnv, _class: JClass, buffer: JByteBuffer, limit: jint) -> jint {
     parse_marshal_inplace(&mut env, buffer, limit, |_, body| Ok(parse_fav_cat(body)))
 }
 
-#[unsafe(no_mangle)]
-#[allow(non_snake_case)]
 #[jni_fn("com.hippo.ehviewer.client.parser.ArchiveParserKt")]
 pub fn parseArchives(
     mut env: JNIEnv,
@@ -106,8 +90,6 @@ pub fn parseArchives(
     }
 }
 
-#[unsafe(no_mangle)]
-#[allow(non_snake_case)]
 #[jni_fn("com.hippo.ehviewer.client.parser.ArchiveParserKt")]
 pub fn parseArchiveUrl(mut env: JNIEnv, _class: JClass, buffer: JByteBuffer, limit: jint) -> jint {
     parse_marshal_inplace(&mut env, buffer, limit, |dom, html| {
@@ -115,8 +97,6 @@ pub fn parseArchiveUrl(mut env: JNIEnv, _class: JClass, buffer: JByteBuffer, lim
     })
 }
 
-#[unsafe(no_mangle)]
-#[allow(non_snake_case)]
 #[jni_fn("com.hippo.ehviewer.client.parser.ProfileParser")]
 pub fn parseProfileUrl(mut env: JNIEnv, _class: JClass, buffer: JByteBuffer, limit: jint) -> jint {
     parse_marshal_inplace(&mut env, buffer, limit, |dom, _| {
@@ -124,8 +104,6 @@ pub fn parseProfileUrl(mut env: JNIEnv, _class: JClass, buffer: JByteBuffer, lim
     })
 }
 
-#[unsafe(no_mangle)]
-#[allow(non_snake_case)]
 #[jni_fn("com.hippo.ehviewer.client.parser.ProfileParser")]
 pub fn parseProfile(mut env: JNIEnv, _class: JClass, buffer: JByteBuffer, limit: jint) -> jint {
     parse_marshal_inplace(&mut env, buffer, limit, |dom, _| {

--- a/app/src/main/rust/src/img/core.rs
+++ b/app/src/main/rust/src/img/core.rs
@@ -5,7 +5,6 @@ pub type Rgba8888 = Rgba<u8>;
 pub type Rgb565 = Luma<u16>;
 pub type RgbaF16 = Luma<u64>;
 
-#[allow(dead_code)]
 pub trait ImageConsumer<R> {
     fn apply<T: CustomPixel>(self, buffer: &ImageBuffer<T, &[T::Subpixel]>) -> Result<R>;
 }

--- a/app/src/main/rust/src/lib.rs
+++ b/app/src/main/rust/src/lib.rs
@@ -2,8 +2,8 @@
 #![feature(never_type)]
 
 mod ffi;
-mod img;
-mod parser;
+pub mod img;
+pub mod parser;
 
 use std::fmt::{Debug, Display, Formatter};
 use tl::{Bytes, HTMLTag, Node, NodeHandle, Parser, VDom};

--- a/app/src/main/rust/src/parser/config.rs
+++ b/app/src/main/rust/src/parser/config.rs
@@ -1,7 +1,6 @@
 use crate::regex;
 use quick_xml::escape::unescape;
 
-#[allow(dead_code)]
 pub fn parse_fav_cat(html: &str) -> Vec<String> {
     regex!("<input type=\"text\" name=\"favorite_\\d\" value=\"([^\"]+)\"")
         .captures_iter(html)

--- a/app/src/main/rust/src/parser/fav.rs
+++ b/app/src/main/rust/src/parser/fav.rs
@@ -14,7 +14,6 @@ pub struct FavResult {
     galleryListResult: GalleryListResult,
 }
 
-#[allow(dead_code)]
 pub fn parse_fav(dom: &VDom, parser: &Parser, html: &str) -> Result<FavResult> {
     if html.contains("This page requires you to log on.</p>") {
         bail!(EhError::NeedLogin)

--- a/app/src/main/rust/src/parser/home.rs
+++ b/app/src/main/rust/src/parser/home.rs
@@ -11,7 +11,6 @@ pub struct Limits {
     resetCost: i32,
 }
 
-#[allow(dead_code)]
 pub fn parse_limit(dom: &VDom, parser: &Parser) -> Option<Limits> {
     let limit_box = get_vdom_first_element_by_class_name(dom, "homebox")?.as_tag()?;
     let vec = limit_box

--- a/app/src/main/rust/src/parser/list.rs
+++ b/app/src/main/rust/src/parser/list.rs
@@ -193,7 +193,6 @@ fn parse_gallery_info(node: &Node, parser: &Parser) -> Option<BaseGalleryInfo> {
     })
 }
 
-#[allow(dead_code)]
 pub fn parse_info_list(dom: &VDom, parser: &Parser, str: &str) -> Result<GalleryListResult> {
     if str.contains("<p>You do not have any watched tags") {
         bail!(EhError::NoWatched)

--- a/app/src/main/rust/src/parser/torrent.rs
+++ b/app/src/main/rust/src/parser/torrent.rs
@@ -17,7 +17,6 @@ pub struct Torrent {
     name: String,
 }
 
-#[allow(dead_code)]
 pub fn parse_torrent_list(dom: &VDom, parser: &Parser) -> Result<Vec<Torrent>> {
     let list = dom.query_selector("table").context("No Table")?.filter_map(|e| {
         let html = e.get(parser)?.inner_html(parser);


### PR DESCRIPTION
* Make `img` and `parser` public to get rid of dead code warnings
* Remove redundant `no_mangle` and `allow(non_snake_case)` as `jni_fn` already adds them