### PR TITLE
Fix a potential UAF

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/coil/AnimatedWebPDrawable.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/coil/AnimatedWebPDrawable.kt
@@ -133,7 +133,9 @@ class AnimatedWebPDrawable(private val source: ByteBuffer) : Drawable(), Animata
     }
 
     fun dispose() {
-        nativeDestroyDecoder(decoder)
+        decodeScope.launch {
+            nativeDestroyDecoder(decoder)
+        }
     }
 }
 


### PR DESCRIPTION
`dispose` may get called while decoding.