### PR TITLE
Actually fix the UAF

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/coil/AnimatedWebPDrawable.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/coil/AnimatedWebPDrawable.kt
@@ -15,8 +15,11 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 // Hold a reference to the buffer as it's used by the decoder
 @Suppress("CanBeParameter")
@@ -133,9 +136,10 @@ class AnimatedWebPDrawable(private val source: ByteBuffer) : Drawable(), Animata
     }
 
     fun dispose() {
-        decodeScope.launch {
-            nativeDestroyDecoder(decoder)
+        runBlocking {
+            decodeScope.coroutineContext.job.cancelAndJoin()
         }
+        nativeDestroyDecoder(decoder)
     }
 }
 


### PR DESCRIPTION
The archive may be closed before the decoding job finishes.

This reverts commit 4b25fb8363facfc5868ffcf35b12c855aa44924f.