### PR TITLE
[Reader] Fix crash when dismissing filter settings

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/reader/ReaderScreen.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/reader/ReaderScreen.kt
@@ -366,7 +366,6 @@ fun ReaderScreen(pageLoader: PageLoader, info: BaseGalleryInfo?) {
                         ) {
                             SettingsPager(modifier = Modifier.fillMaxSize()) { page ->
                                 isColorFilter = page == 2
-                                appbarVisible = !isColorFilter
                             }
                         }
                     }


### PR DESCRIPTION
That's an upstream bug, but we don't need to hide reader app bars anyway since we don't have Tachiyomi's top app bar in reader.