### PR TITLE
Work around ANR on DownloadManager initialization

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/EhApplication.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/EhApplication.kt
@@ -133,6 +133,7 @@ class EhApplication :
                 if (DownloadManager.labelList.isNotEmpty() && Settings.downloadFilterMode !in Settings.snapshot()) {
                     Settings.downloadFilterMode.value = DownloadsFilterMode.CUSTOM.flag
                 }
+                initialized = true
                 DownloadManager.readMetadataFromLocal()
             }
             launch {
@@ -214,6 +215,10 @@ class EhApplication :
     }
 
     companion object {
+        @Volatile
+        var initialized = false
+            private set
+
         val ktorClient by lazy {
             if (isAtLeastSExtension7 && Settings.enableCronet.value) {
                 HttpClient(Cronet) {

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/MainActivity.kt
@@ -111,6 +111,7 @@ import com.ehviewer.core.ui.icons.filled.Subscriptions
 import com.ehviewer.core.ui.util.LocalSnackBarFabPadding
 import com.ehviewer.core.ui.util.LocalWindowSizeClass
 import com.ehviewer.core.util.withIOContext
+import com.hippo.ehviewer.EhApplication.Companion.initialized
 import com.hippo.ehviewer.Settings
 import com.hippo.ehviewer.client.data.ListUrlBuilder
 import com.hippo.ehviewer.client.parser.GalleryDetailUrlParser
@@ -200,7 +201,7 @@ class MainActivity : EhActivity() {
 
     @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
     override fun onCreate(savedInstanceState: Bundle?) {
-        installSplashScreen()
+        installSplashScreen().setKeepOnScreenCondition { !initialized }
         super.onCreate(savedInstanceState)
         setMD3Content {
             val configuration = LocalConfiguration.current


### PR DESCRIPTION
Resolve #2588 

That's not ideal; we should refactor the DownloadManager so it doesn't load the entire download list on initialization in the future.