### PR TITLE
Downgrade rust-nightly to 2025-09-23

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -143,9 +143,8 @@ corrosion_import_crate(
         MANIFEST_PATH ../rust/Cargo.toml
         LOCKED
         FEATURES $<IF:$<VERSION_GREATER_EQUAL:${ANDROID_NATIVE_API_LEVEL},26>,android-26,android>
-        FLAGS $<$<NOT:$<CONFIG:Debug>>:-Z build-std=std,panic_abort>
+        FLAGS $<$<NOT:$<CONFIG:Debug>>:-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort>
 )
-corrosion_add_target_rustflags(ehviewer_rust $<$<NOT:$<CONFIG:Debug>>:-Z unstable-options -C panic=immediate-abort>)
 corrosion_link_libraries(ehviewer_rust android jnigraphics log webp webpdemux)
 
 # Build and link our app's native lib

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-10-01"
+channel = "nightly-2025-09-23"
 components = ["rustfmt", "clippy", "rust-src"]
 targets = ["aarch64-linux-android", "x86_64-linux-android"]
 profile = "minimal"


### PR DESCRIPTION
2025-09-24 and later have a +25% (141KB) binary size regression

This reverts commit 9a2c0d7121c004bf131a6d131a964fd96dfb3c39.

Upstream bug: https://github.com/rust-lang/rust/issues/147257