### PR TITLE
Underline solid tags when opted in

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryTag.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryTag.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ehviewer.core.model.GalleryTagGroup
@@ -60,6 +61,7 @@ fun GalleryTags(
                             BaseRoundText(
                                 text = translation,
                                 weak = power == PowerStatus.Weak,
+                                solid = power == PowerStatus.Solid && showVote,
                                 modifier = Modifier.combinedClickable(
                                     onClick = { onTagClick(tag) },
                                     onLongClick = {
@@ -89,6 +91,7 @@ private fun BaseRoundText(
     text: String,
     modifier: Modifier = Modifier,
     weak: Boolean = false,
+    solid: Boolean = false,
     isGroup: Boolean = false,
 ) {
     val bgColor = if (isGroup) {
@@ -106,6 +109,7 @@ private fun BaseRoundText(
             modifier = modifier.padding(horizontal = 12.dp, vertical = 4.dp).width(IntrinsicSize.Max),
             color = LocalContentColor.current.let { if (weak) it.copy(0.5F) else it },
             style = MaterialTheme.typography.labelLarge.includeFontPadding,
+            textDecoration = if (solid) TextDecoration.Underline else null,
         )
     }
 }


### PR DESCRIPTION
<img width="1080" height="891" alt="Screenshot_20251009-210228_Paranoid Launcher" src="https://github.com/user-attachments/assets/063e4076-5473-4602-a58a-1107236bea79" />
