### PR TITLE
Revert "Use to the new panic-immediate-abort cargo feature"

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -145,6 +145,7 @@ corrosion_import_crate(
         FEATURES $<IF:$<VERSION_GREATER_EQUAL:${ANDROID_NATIVE_API_LEVEL},26>,android-26,android>
         FLAGS $<$<NOT:$<CONFIG:Debug>>:-Z build-std -Z build-std-features=>
 )
+corrosion_add_target_rustflags(ehviewer_rust $<$<NOT:$<CONFIG:Debug>>:-Z unstable-options -C panic=immediate-abort>)
 corrosion_link_libraries(ehviewer_rust android jnigraphics log webp webpdemux)
 
 # Build and link our app's native lib

--- a/app/src/main/rust/Cargo.toml
+++ b/app/src/main/rust/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["panic-immediate-abort"]
-
 [package]
 name = "ehviewer_rust"
 version = "0.0.0"
@@ -36,7 +34,7 @@ reqwest = "0.12"
 tokio = { version = "1", features = ["macros"] }
 
 [profile.release]
-panic = "immediate-abort"
+panic = "abort"
 strip = true
 lto = true
 codegen-units = 1


### PR DESCRIPTION
This reverts commit cf10e2ff6d6c540ce2683cc0ce9d8a316ba45f03.

Reason for revert: Incompatible with renovate