### PR TITLE
Revert "Use the upstream `PaddingValues.plus`"

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryList.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/main/GalleryList.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.pulltorefresh.pullToRefresh
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -44,6 +45,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
@@ -66,6 +68,15 @@ import com.hippo.ehviewer.util.displayString
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
+
+@Stable
+operator fun PaddingValues.plus(r: PaddingValues) = object : PaddingValues {
+    val l = this@plus
+    override fun calculateBottomPadding() = l.calculateBottomPadding() + r.calculateBottomPadding()
+    override fun calculateLeftPadding(layoutDirection: LayoutDirection) = l.calculateLeftPadding(layoutDirection) + r.calculateLeftPadding(layoutDirection)
+    override fun calculateRightPadding(layoutDirection: LayoutDirection) = l.calculateRightPadding(layoutDirection) + r.calculateRightPadding(layoutDirection)
+    override fun calculateTopPadding() = l.calculateTopPadding() + r.calculateTopPadding()
+}
 
 @Composable
 context(_: CoroutineScope, _: Context)

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/DownloadsScreen.kt
@@ -123,6 +123,7 @@ import com.hippo.ehviewer.ui.Screen
 import com.hippo.ehviewer.ui.confirmRemoveDownloadRange
 import com.hippo.ehviewer.ui.main.DownloadCard
 import com.hippo.ehviewer.ui.main.GalleryInfoGridItem
+import com.hippo.ehviewer.ui.main.plus
 import com.hippo.ehviewer.ui.navToReader
 import com.hippo.ehviewer.ui.showMoveDownloadLabelList
 import com.hippo.ehviewer.ui.tools.DialogState

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/ImageSearchScreen.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/ImageSearchScreen.kt
@@ -37,6 +37,7 @@ import com.hippo.ehviewer.client.data.ListUrlBuilder
 import com.hippo.ehviewer.client.data.ListUrlBuilder.Companion.MODE_IMAGE_SEARCH
 import com.hippo.ehviewer.ui.Screen
 import com.hippo.ehviewer.ui.main.ImageSearch
+import com.hippo.ehviewer.ui.main.plus
 import com.hippo.ehviewer.util.pickVisualMedia
 import com.hippo.ehviewer.util.sha1
 import com.ramcosta.composedestinations.annotation.Destination


### PR DESCRIPTION
Reverts FooIbar/EhViewer#2660
Revert reason: https://github.com/androidx/androidx/commit/e19d9ad03237e9dd05a19b0479beb0abc4ad3cc4