### PR TITLE
Migrate CMP dependencies to version catalog

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -180,10 +180,6 @@ dependencies {
     implementation(libs.androidx.biometric)
     implementation(libs.androidx.browser)
 
-    // https://developer.android.com/jetpack/androidx/releases/compose-material3
-    api(platform(libs.compose.bom))
-    implementation(libs.bundles.compose)
-
     implementation(libs.compose.destinations.core)
     ksp(libs.compose.destinations.compiler)
 

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.compose.compose
-
 plugins {
     alias(libs.plugins.ehviewer.multiplatform.library.compose)
 }
@@ -9,20 +7,20 @@ kotlin {
         commonMain {
             dependencies {
                 api(projects.core.common)
-                api(compose.material3)
-                api(compose.materialIconsExtended)
+                api(libs.compose.material3)
+                api(libs.compose.material.icons.extended)
                 api(libs.compose.material3.adaptive)
                 api(libs.androidx.lifecycle.compose)
                 api(libs.androidx.lifecycle.viewmodel.compose)
-                implementation(compose("org.jetbrains.compose.ui:ui-backhandler"))
-                implementation(compose.preview)
+                implementation(libs.compose.ui.backhandler)
+                implementation(libs.compose.ui.tooling.preview)
             }
         }
 
         androidMain {
             dependencies {
                 api(project.dependencies.platform(libs.compose.bom))
-                api(libs.bundles.compose)
+                api(libs.compose.foundation)
                 implementation(libs.androidx.activity.compose)
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,12 +73,12 @@ coil-network = { module = "io.coil-kt.coil3:coil-network-ktor3" }
 
 compose-bom = { module = "androidx.compose:compose-bom-alpha", version.ref = "compose-bom" }
 compose-foundation = { module = "androidx.compose.foundation:foundation", version = "1.10.0-SNAPSHOT"  }
-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
-compose-material3 = { module = "androidx.compose.material3:material3" }
+compose-material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version = "1.7.3" }
+compose-material3 = { module = "org.jetbrains.compose.material3:material3", version = "1.9.0" }
 compose-material3-adaptive = { module = "org.jetbrains.compose.material3.adaptive:adaptive", version = "1.2.0" }
+compose-ui-backhandler = { module = "org.jetbrains.compose.ui:ui-backhandler", version.ref = "compose-multiplatform" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
-compose-ui-util = { module = "androidx.compose.ui:ui-util" }
+compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "compose-multiplatform" }
 
 compose-destinations-core = { module = "io.github.raamcosta.compose-destinations:core", version.ref = "compose-destinations" }
 compose-destinations-compiler = { module = "io.github.raamcosta.compose-destinations:ksp", version.ref = "compose-destinations" }
@@ -135,7 +135,6 @@ spotless-gradlePlugin = { module = "com.diffplug.spotless:spotless-plugin-gradle
 [bundles]
 arrow = ["arrow-fx-coroutines", "arrow-functions", "arrow-resilience"]
 coil = ["coil-compose", "coil-gif", "coil-network"]
-compose = ["compose-foundation", "compose-material-icons-extended", "compose-material3", "compose-material3-adaptive", "compose-ui-util"]
 kotlinx-serialization = ["serialization-cbor", "serialization-json", "serialization-json-io", "serialization-xml", "serialization-xml-io"]
 splitties = ["splitties-appctx", "splitties-arch-room", "splitties-systemservices"]
 


### PR DESCRIPTION
Gradle plugin dependency aliases are deprecated.