### PR TITLE
Lower image target size to reduce moiré patterns

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/image/Image.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/image/Image.kt
@@ -32,8 +32,9 @@ import coil3.request.CachePolicy
 import coil3.request.ErrorResult
 import coil3.request.SuccessResult
 import coil3.request.allowHardware
-import coil3.size.Dimension
+import coil3.request.maxBitmapSize
 import coil3.size.Precision
+import coil3.size.Scale
 import coil3.size.Size
 import coil3.size.SizeResolver
 import com.ehviewer.core.files.openFileDescriptor
@@ -90,8 +91,10 @@ class Image private constructor(image: CoilImage, private val src: ImageSource) 
     }
 
     companion object {
-        private val targetWidth = appCtx.resources.displayMetrics.widthPixels * 3
-        private val sizeResolver = SizeResolver(Size(targetWidth, Dimension.Undefined))
+        private val sizeResolver = with(appCtx.resources.displayMetrics) {
+            val targetSize = minOf(widthPixels, heightPixels) * 4 / 3
+            SizeResolver(Size(targetSize, targetSize))
+        }
 
         private suspend fun Either<ByteBufferSource, PathSource>.decodeCoil(checkExtraneousAds: Boolean): CoilImage {
             val request = with(appCtx) {
@@ -99,7 +102,9 @@ class Image private constructor(image: CoilImage, private val src: ImageSource) 
                     onLeft { data(it.source) }
                     onRight { data(it.source.toUri()) }
                     size(sizeResolver)
+                    scale(Scale.FILL)
                     precision(Precision.INEXACT)
+                    maxBitmapSize(Size.ORIGINAL)
                     allowHardware(false)
                     hardwareThreshold(Settings.hardwareBitmapThreshold.value)
                     maybeCropBorder(Settings.cropBorder.value)


### PR DESCRIPTION
This partially reverts commit 63164dc70a133a87cdebb9c6b460e096f40d998c.
I can't remember why that was needed.

Workaround for #1039 