### PR TITLE
Add batch selection actions for gallery lists

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/CommonOperations.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/CommonOperations.kt
@@ -177,6 +177,35 @@ suspend fun startDownload(forceDefault: Boolean, vararg galleryInfos: BaseGaller
 }
 
 context(_: DialogState)
+suspend fun awaitFavoriteSlot(): Int {
+    val localFav = appCtx.getString(R.string.local_favorites)
+    val items = buildList {
+        add(localFav)
+        if (Settings.hasSignedIn.value) {
+            addAll(Settings.favCat)
+        }
+    }
+    val selected = awaitSelectItem(items, R.string.add_favorites_dialog_title)
+    return if (selected == 0) LOCAL_FAVORITED else selected - 1
+}
+
+suspend fun addToFavorites(galleryInfo: GalleryInfo, slot: Int): Boolean {
+    val localFavorited = EhDB.containLocalFavorites(galleryInfo.gid)
+    return if (slot == LOCAL_FAVORITED) {
+        if (!localFavorited) {
+            EhDB.putLocalFavorites(galleryInfo)
+            if (galleryInfo.favoriteSlot == NOT_FAVORITED) {
+                galleryInfo.favoriteSlot = LOCAL_FAVORITED
+            }
+            FavouriteStatusRouter.notify(galleryInfo)
+        }
+        true
+    } else {
+        doModifyFavorites(galleryInfo, slot, localFavorited)
+    }
+}
+
+context(_: DialogState)
 suspend fun modifyFavorites(galleryInfo: GalleryInfo): Boolean {
     val localFavorited = EhDB.containLocalFavorites(galleryInfo.gid)
     if (Settings.hasSignedIn.value) {
@@ -297,17 +326,17 @@ suspend fun doGalleryInfoAction(info: BaseGalleryInfo) {
         }
     }
     val selected = awaitSelectItemWithIcon(items, EhUtils.getSuitableTitle(info))
-    when (selected) {
-        0 -> {
+    when {
+        selected == 0 -> {
             EhDB.putHistoryInfo(info)
             navToReader(info)
         }
-        1 -> if (downloaded) {
+        selected == 1 -> if (downloaded) {
             confirmRemoveDownload(info)
         } else {
             startDownload(false, info)
         }
-        2 -> if (favorited) {
+        selected == 2 -> if (favorited) {
             runSuspendCatching {
                 removeFromFavorites(info)
                 tip(R.string.remove_from_favorite_success)
@@ -322,7 +351,7 @@ suspend fun doGalleryInfoAction(info: BaseGalleryInfo) {
                 tip(R.string.add_to_favorite_failure)
             }
         }
-        3 -> showMoveDownloadLabel(info)
+        selected == 3 && downloaded -> showMoveDownloadLabel(info)
     }
 }
 

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/GalleryListScreen.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/GalleryListScreen.kt
@@ -25,6 +25,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Help
 import androidx.compose.material.icons.automirrored.filled.LastPage
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.DoneAll
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.HeartBroken
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Reorder
 import androidx.compose.material.icons.filled.Shuffle
@@ -46,6 +49,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -71,6 +75,7 @@ import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
 import com.ehviewer.core.database.model.QuickSearch
 import com.ehviewer.core.i18n.R
+import com.ehviewer.core.model.BaseGalleryInfo
 import com.ehviewer.core.ui.component.FAB_ANIMATE_TIME
 import com.ehviewer.core.ui.component.FabLayout
 import com.ehviewer.core.ui.component.FastScrollLazyColumn
@@ -105,15 +110,17 @@ import com.hippo.ehviewer.client.parser.GalleryPageUrlParser
 import com.hippo.ehviewer.collectAsState
 import com.hippo.ehviewer.ui.DrawerHandle
 import com.hippo.ehviewer.ui.Screen
+import com.hippo.ehviewer.ui.addToFavorites
+import com.hippo.ehviewer.ui.awaitFavoriteSlot
 import com.hippo.ehviewer.ui.awaitSelectDate
 import com.hippo.ehviewer.ui.destinations.ProgressScreenDestination
-import com.hippo.ehviewer.ui.doGalleryInfoAction
 import com.hippo.ehviewer.ui.main.AdvancedSearchOption
 import com.hippo.ehviewer.ui.main.AvatarIcon
 import com.hippo.ehviewer.ui.main.GalleryInfoGridItem
 import com.hippo.ehviewer.ui.main.GalleryInfoListItem
 import com.hippo.ehviewer.ui.main.GalleryList
 import com.hippo.ehviewer.ui.main.SearchFilter
+import com.hippo.ehviewer.ui.removeFromFavorites
 import com.hippo.ehviewer.ui.tools.DialogState
 import com.hippo.ehviewer.ui.tools.awaitConfirmationOrCancel
 import com.hippo.ehviewer.ui.tools.awaitInputText
@@ -127,6 +134,7 @@ import com.ramcosta.composedestinations.spec.Direction
 import kotlin.math.roundToInt
 import kotlin.random.Random
 import kotlinx.coroutines.delay
+import moe.tarsin.coroutines.runSwallowingWithUI
 import moe.tarsin.navigate
 import moe.tarsin.snackbar
 import moe.tarsin.string
@@ -162,13 +170,15 @@ fun AnimatedVisibilityScope.GalleryListScreen(
     var searchBarOffsetY by remember { mutableIntStateOf(0) }
     var fabExpanded by remember { mutableStateOf(false) }
     var fabHidden by remember { mutableStateOf(false) }
+    var selectMode by rememberSaveable { mutableStateOf(false) }
+    val checkedInfoMap = remember { mutableStateMapOf<Long, BaseGalleryInfo>() }
 
     val animateItems by Settings.animateItems.collectAsState()
 
     var category by rememberMutableStateInDataStore("SearchCategory") { EhUtils.ALL_CATEGORY }
     var advancedSearchOption by rememberMutableStateInDataStore("AdvancedSearchOption") { AdvancedSearchOption() }
 
-    DrawerHandle(!searchBarExpanded)
+    DrawerHandle(!searchBarExpanded && !selectMode)
 
     LaunchedEffect(urlBuilder) {
         if (urlBuilder.category != EhUtils.NONE) category = urlBuilder.category
@@ -196,6 +206,20 @@ fun AnimatedVisibilityScope.GalleryListScreen(
     ReportDrawnWhen { data.loadState.refresh !is LoadState.Loading }
     FavouriteStatusRouter.Observe(data)
     val listMode by Settings.listMode.collectAsState()
+
+    fun enterSelection(info: BaseGalleryInfo? = null) {
+        selectMode = true
+        info?.let { checkedInfoMap[it.gid] = it }
+        fabExpanded = true
+    }
+
+    fun toggleSelection(info: BaseGalleryInfo) {
+        if (info.gid in checkedInfoMap) {
+            checkedInfoMap.remove(info.gid)
+        } else {
+            checkedInfoMap[info.gid] = info
+        }
+    }
 
     val entries = stringArrayResource(id = com.hippo.ehviewer.R.array.toplist_entries)
     val values = stringArrayResource(id = com.hippo.ehviewer.R.array.toplist_values)
@@ -267,7 +291,7 @@ fun AnimatedVisibilityScope.GalleryListScreen(
                                     snackbar(invalidImageQuickSearch)
                                 } else {
                                     // itemCount == 0 is treated as error, so no need to check here
-                                    val firstItem = data.itemSnapshotList.items[getFirstVisibleItemIndex()]
+                                    val firstItem = data.itemSnapshotList.items.getOrNull(getFirstVisibleItemIndex()) ?: return@launch
                                     val next = firstItem.gid + 1
                                     quickSearchList.fastForEach { q ->
                                         if (urlBuilder.equalsQuickSearch(q)) {
@@ -444,6 +468,8 @@ fun AnimatedVisibilityScope.GalleryListScreen(
         override val destination = ProgressScreenDestination(gid, pToken, page)
     }
 
+    val title = if (selectMode) stringResource(R.string.batch_selection_title, checkedInfoMap.size) else suitableTitle
+
     fun onApplySearch(query: String) = launchIO {
         val builder = ListUrlBuilder()
         val oldMode = urlBuilder.mode
@@ -477,7 +503,7 @@ fun AnimatedVisibilityScope.GalleryListScreen(
             searchBarExpanded = it
             fabHidden = it
         },
-        title = suitableTitle,
+        title = title,
         searchFieldHint = searchBarHint,
         searchFieldState = searchFieldState,
         suggestionProvider = {
@@ -533,24 +559,54 @@ fun AnimatedVisibilityScope.GalleryListScreen(
             listMode = listMode,
             detailListState = listState,
             detailItemContent = { info ->
-                GalleryInfoListItem(
-                    onClick = { navigate(info.asDst()) },
-                    onLongClick = { launch { doGalleryInfoAction(info) } },
-                    info = info,
-                    showPages = showPages,
-                    showProgress = showProgress,
-                    modifier = Modifier.height(height),
-                )
+                val checked = info.gid in checkedInfoMap
+                CheckableItem(
+                    checked = checked,
+                    modifier = Modifier.thenIf(animateItems) { animateItem() },
+                ) { interactionSource ->
+                    GalleryInfoListItem(
+                        onClick = {
+                            if (selectMode) {
+                                toggleSelection(info)
+                            } else {
+                                navigate(info.asDst())
+                            }
+                        },
+                        onLongClick = {
+                            enterSelection(info)
+                        },
+                        info = info,
+                        showPages = showPages,
+                        showProgress = showProgress,
+                        modifier = Modifier.height(height),
+                        interactionSource = interactionSource,
+                    )
+                }
             },
             thumbListState = gridState,
             thumbItemContent = { info ->
-                GalleryInfoGridItem(
-                    onClick = { navigate(info.asDst()) },
-                    onLongClick = { launch { doGalleryInfoAction(info) } },
-                    info = info,
-                    showPages = showPages,
-                    showProgress = showProgress,
-                )
+                val checked = info.gid in checkedInfoMap
+                CheckableItem(
+                    checked = checked,
+                    modifier = Modifier.thenIf(animateItems) { animateItem() },
+                ) { interactionSource ->
+                    GalleryInfoGridItem(
+                        onClick = {
+                            if (selectMode) {
+                                toggleSelection(info)
+                            } else {
+                                navigate(info.asDst())
+                            }
+                        },
+                        onLongClick = {
+                            enterSelection(info)
+                        },
+                        info = info,
+                        showPages = showPages,
+                        showProgress = showProgress,
+                        interactionSource = interactionSource,
+                    )
+                }
             },
             searchBarOffsetY = { searchBarOffsetY },
             onRefresh = {
@@ -575,43 +631,83 @@ fun AnimatedVisibilityScope.GalleryListScreen(
     )
 
     FabLayout(
-        hidden = hideFab,
-        expanded = fabExpanded,
-        onExpandChanged = { fabExpanded = it },
-        autoCancel = true,
+        hidden = hideFab && !selectMode,
+        expanded = fabExpanded || selectMode,
+        onExpandChanged = {
+            fabExpanded = it
+            if (selectMode) {
+                selectMode = false
+                checkedInfoMap.clear()
+            }
+        },
+        autoCancel = !selectMode,
     ) {
-        if (urlBuilder.mode in arrayOf(MODE_NORMAL, MODE_UPLOADER, MODE_TAG)) {
-            onClick(Icons.Default.Shuffle) {
-                urlBuilder.setRange(Random.nextInt(100))
+        if (!selectMode) {
+            if (urlBuilder.mode in arrayOf(MODE_NORMAL, MODE_UPLOADER, MODE_TAG)) {
+                onClick(Icons.Default.Shuffle) {
+                    urlBuilder.setRange(Random.nextInt(100))
+                    data.refresh()
+                }
+            }
+            onClick(Icons.Default.Refresh) {
+                urlBuilder.setRange(0)
                 data.refresh()
             }
-        }
-        onClick(Icons.Default.Refresh) {
-            urlBuilder.setRange(0)
-            data.refresh()
-        }
-        if (urlBuilder.mode != MODE_WHATS_HOT) {
-            onClick(EhIcons.Default.GoTo) {
-                if (isTopList) {
-                    val hint = string(R.string.go_to_hint, urlBuilder.page, TOPLIST_PAGES)
-                    val text = awaitInputText(title = gotoTitle, hint = hint, isNumber = true) { oriText ->
-                        val goto = ensureNotNull(oriText.trim().toIntOrNull()) { invalidNum }
-                        ensure(goto in 1..TOPLIST_PAGES) { outOfRange }
+            if (urlBuilder.mode != MODE_WHATS_HOT) {
+                onClick(EhIcons.Default.GoTo) {
+                    if (isTopList) {
+                        val hint = string(R.string.go_to_hint, urlBuilder.page, TOPLIST_PAGES)
+                        val text = awaitInputText(title = gotoTitle, hint = hint, isNumber = true) { oriText ->
+                            val goto = ensureNotNull(oriText.trim().toIntOrNull()) { invalidNum }
+                            ensure(goto in 1..TOPLIST_PAGES) { outOfRange }
+                        }
+                        urlBuilder.page = text.trim().toInt()
+                    } else {
+                        val date = awaitSelectDate()
+                        urlBuilder.setSeek(date)
                     }
-                    urlBuilder.page = text.trim().toInt()
-                } else {
-                    val date = awaitSelectDate()
-                    urlBuilder.setSeek(date)
+                    data.refresh()
                 }
-                data.refresh()
+                onClick(Icons.AutoMirrored.Default.LastPage) {
+                    if (isTopList) {
+                        urlBuilder.page = TOPLIST_PAGES
+                    } else {
+                        urlBuilder.setIndex("1", false)
+                    }
+                    data.refresh()
+                }
             }
-            onClick(Icons.AutoMirrored.Default.LastPage) {
-                if (isTopList) {
-                    urlBuilder.page = TOPLIST_PAGES
+        } else {
+            onClick(Icons.Default.DoneAll, autoClose = false) {
+                checkedInfoMap.putAll(data.itemSnapshotList.items.associateBy { it.gid })
+            }
+            onClick(Icons.Default.Favorite) {
+                val info = checkedInfoMap.values.toList()
+                if (info.isEmpty()) {
+                    snackbar(string(R.string.no_selected_galleries))
                 } else {
-                    urlBuilder.setIndex("1", false)
+                    val slot = awaitFavoriteSlot()
+                    runSwallowingWithUI {
+                        info.forEach { addToFavorites(it, slot) }
+                        selectMode = false
+                        checkedInfoMap.clear()
+                    }
                 }
-                data.refresh()
+            }
+            onClick(Icons.Default.HeartBroken) {
+                val info = checkedInfoMap.values.toList()
+                if (info.isEmpty()) {
+                    snackbar(string(R.string.no_selected_galleries))
+                } else {
+                    awaitConfirmationOrCancel(title = R.string.remove_from_favourites) {
+                        Text(text = stringResource(R.string.delete_favorites_dialog_message, info.size))
+                    }
+                    runSwallowingWithUI {
+                        info.forEach { removeFromFavorites(it) }
+                        selectMode = false
+                        checkedInfoMap.clear()
+                    }
+                }
             }
         }
     }

--- a/core/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/core/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -96,6 +96,8 @@
     <string name="search_sft">Tags</string>
     <string name="select_image">Select image</string>
     <string name="select_image_first">Please select image first</string>
+    <string name="batch_selection_title">%d selected</string>
+    <string name="no_selected_galleries">No galleries selected</string>
     <string name="add_to_favourites">Add to favourites</string>
     <string name="remove_from_favourites">Remove from favourites</string>
     <string name="delete_downloads">Delete downloads</string>

--- a/core/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/core/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -80,6 +80,8 @@
     <string name="search_sft">标签</string>
     <string name="select_image">选择图片</string>
     <string name="select_image_first">请先选择图片</string>
+    <string name="batch_selection_title">已选择 %d 项</string>
+    <string name="no_selected_galleries">尚未选择画廊</string>
     <string name="add_to_favourites">收藏</string>
     <string name="remove_from_favourites">移除收藏</string>
     <string name="delete_downloads">删除下载</string>


### PR DESCRIPTION
## Summary

This PR adds an opt-in batch selection mode to gallery lists.

It supports:
- selecting/deselecting loaded gallery items
- selecting all currently loaded items
- batch favorite with one favorite slot selection
- batch unfavorite with confirmation
- copying torrent magnet links for selected galleries

When multiple torrents are available for one gallery, the selected torrent can be chosen by:
- largest size
- latest time

The chosen magnet links are copied to the clipboard as newline-separated text.

## Behavior

Existing gallery item behavior is preserved:
- normal tap still opens/navigates to the gallery
- normal long press still opens the existing single-gallery action menu

Batch mode is only enabled explicitly from:
- the top bar batch selection action
- the existing single-gallery action menu

In batch mode, tapping a gallery toggles its selected state.

## UI

Batch mode uses the existing selectable item overlay style.

For gallery lists, the selection indicator reserves a stable top-right area while batch mode is active. Unselected items show an outline indicator, and selected items show a checked indicator. This avoids layout shifts and keeps long titles from colliding with the selected state indicator.

## Notes

"Select all" only selects currently loaded paging items.

Batch favorite/unfavorite operations are processed sequentially to avoid firing many requests at once.

## Test plan

Passed on fork CI:
- check
- default
- marshmallow

CI run:
https://github.com/Vivitoto/EhViewer/actions/runs/34434538759

A pre-release APK build for manual testing is available here:
https://github.com/Vivitoto/EhViewer/releases/tag/batch-gallery-actions-3d07b1e
