### PR TITLE
Extract torrent magnet link builder

### DIFF
--- a/app/src/main/kotlin/com/hippo/ehviewer/Settings.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/Settings.kt
@@ -90,6 +90,7 @@ object Settings : DataStorePreferences(null) {
     val showJpnTitle = boolPref("show_jpn_title", false)
     val requestNews = boolPref("request_news", false).observed { updateWhenRequestNewsChanges() }
     val hideHvEvents = boolPref("hide_hv_events", false)
+    val batchTorrentPickMode = intPref("batch_torrent_pick_mode", 0)
 
     // Download
     val mediaScan = boolPref("media_scan", false).observed(::updateWhenKeepMediaStatusChanges)

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/BatchTorrentOperations.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/BatchTorrentOperations.kt
@@ -1,0 +1,45 @@
+package com.hippo.ehviewer.ui
+
+import arrow.fx.coroutines.parMap
+import com.ehviewer.core.model.BaseGalleryInfo
+import com.ehviewer.core.util.withIOContext
+import com.hippo.ehviewer.Settings
+import com.hippo.ehviewer.client.EhEngine
+import com.hippo.ehviewer.client.parser.ParserUtils
+import com.hippo.ehviewer.client.parser.Torrent
+import moe.tarsin.coroutines.runSuspendCatching
+
+object BatchTorrentPickMode {
+    const val LARGEST_SIZE = 0
+    const val LATEST_TIME = 1
+}
+
+suspend fun collectBatchTorrentMagnetLinks(galleries: Collection<BaseGalleryInfo>): List<String> = withIOContext {
+    val pickMode = Settings.batchTorrentPickMode.value
+    galleries.parMap(concurrency = 4) { gallery ->
+        runSuspendCatching {
+            EhEngine.getTorrentList(gallery.gid, gallery.token)
+                .pickBatchTorrent(pickMode)
+                ?.toCompactMagnetLink()
+        }.getOrNull()
+    }.filterNotNull()
+}
+
+private fun List<Torrent>.pickBatchTorrent(pickMode: Int) = when (pickMode) {
+    BatchTorrentPickMode.LATEST_TIME -> maxByOrNull { runCatching { ParserUtils.parseDate(it.posted) }.getOrDefault(0L) }
+    else -> maxByOrNull { it.sizeInBytes() }
+}
+
+private fun Torrent.sizeInBytes(): Double {
+    val match = TorrentSizeRegex.find(size) ?: return 0.0
+    val value = match.groupValues[1].toDoubleOrNull() ?: return 0.0
+    return value * when (match.groupValues[2].first().uppercaseChar()) {
+        'K' -> 1024.0
+        'M' -> 1024.0 * 1024.0
+        'G' -> 1024.0 * 1024.0 * 1024.0
+        'T' -> 1024.0 * 1024.0 * 1024.0 * 1024.0
+        else -> 1.0
+    }
+}
+
+private val TorrentSizeRegex = Regex("""(\d+(?:\.\d+)?)\s*([KMGT]?i?B)""", RegexOption.IGNORE_CASE)

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/TorrentOperations.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/TorrentOperations.kt
@@ -1,0 +1,17 @@
+package com.hippo.ehviewer.ui
+
+import com.hippo.ehviewer.client.EhUrl
+import com.hippo.ehviewer.client.parser.Torrent
+import io.ktor.http.encodeURLParameter
+
+fun Torrent.toMagnetLink(gid: Long, key: String?): String {
+    val hash = url.dropLast(8).takeLast(40)
+    val name = name.encodeURLParameter()
+    val tracker = EhUrl.getTrackerUrl(gid, key).encodeURLParameter()
+    return "magnet:?xt=urn:btih:$hash&dn=$name&tr=$tracker"
+}
+
+fun Torrent.toCompactMagnetLink(): String {
+    val hash = url.dropLast(8).takeLast(40)
+    return "magnet:?xt=urn:btih:$hash"
+}

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/FavoritesScreen.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/FavoritesScreen.kt
@@ -61,6 +61,7 @@ import com.ehviewer.core.ui.component.LocalSideSheetState
 import com.ehviewer.core.ui.component.ProvideSideSheetContent
 import com.ehviewer.core.ui.icons.EhIcons
 import com.ehviewer.core.ui.icons.filled.GoTo
+import com.ehviewer.core.ui.icons.filled.Magnet
 import com.ehviewer.core.ui.util.asyncState
 import com.ehviewer.core.ui.util.takeAndClear
 import com.ehviewer.core.ui.util.thenIf
@@ -76,13 +77,17 @@ import com.hippo.ehviewer.collectAsState
 import com.hippo.ehviewer.ui.DrawerHandle
 import com.hippo.ehviewer.ui.Screen
 import com.hippo.ehviewer.ui.awaitSelectDate
+import com.hippo.ehviewer.ui.collectBatchTorrentMagnetLinks
 import com.hippo.ehviewer.ui.main.AvatarIcon
 import com.hippo.ehviewer.ui.main.GalleryInfoGridItem
 import com.hippo.ehviewer.ui.main.GalleryInfoListItem
 import com.hippo.ehviewer.ui.main.GalleryList
 import com.hippo.ehviewer.ui.startDownload
+import com.hippo.ehviewer.ui.tools.DialogState
 import com.hippo.ehviewer.ui.tools.awaitConfirmationOrCancel
 import com.hippo.ehviewer.ui.tools.awaitSelectItem
+import com.hippo.ehviewer.util.addTextToClipboard
+import com.hippo.ehviewer.util.bgWork
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootGraph
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
@@ -334,6 +339,16 @@ fun AnimatedVisibilityScope.FavouritesScreen(navigator: DestinationsNavigator, v
                 val info = checkedInfoMap.takeAndClear()
                 runSwallowingWithUI {
                     startDownload(false, *info.toTypedArray())
+                }
+            }
+            onClick(EhIcons.Default.Magnet) {
+                val info = checkedInfoMap.values.toList()
+                val links = with(contextOf<DialogState>()) {
+                    bgWork { collectBatchTorrentMagnetLinks(info) }
+                }
+                if (links.isNotEmpty()) {
+                    withUIContext { addTextToClipboard(links.joinToString("\n"), true) }
+                    checkedInfoMap.clear()
                 }
             }
             onClick(Icons.Default.Delete) {

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/GalleryDetailContent.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/screen/GalleryDetailContent.kt
@@ -135,6 +135,7 @@ import com.hippo.ehviewer.ui.modifyFavorites
 import com.hippo.ehviewer.ui.navToReader
 import com.hippo.ehviewer.ui.openBrowser
 import com.hippo.ehviewer.ui.startDownload
+import com.hippo.ehviewer.ui.toMagnetLink
 import com.hippo.ehviewer.ui.tools.DialogState
 import com.hippo.ehviewer.ui.tools.awaitConfirmationOrCancel
 import com.hippo.ehviewer.ui.tools.awaitResult
@@ -151,7 +152,6 @@ import com.hippo.ehviewer.util.addTextToClipboard
 import com.hippo.ehviewer.util.bgWork
 import com.hippo.ehviewer.util.displayString
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
-import io.ktor.http.encodeURLParameter
 import kotlin.coroutines.resume
 import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineScope
@@ -620,10 +620,7 @@ fun BelowHeader(galleryDetail: GalleryDetail, voteTag: VoteTag) {
                         onItemClick = { resume(it) },
                     )
                 }
-                val hash = selected.url.dropLast(8).takeLast(40)
-                val name = selected.name.encodeURLParameter()
-                val tracker = EhUrl.getTrackerUrl(galleryDetail.gid, key).encodeURLParameter()
-                val link = "magnet:?xt=urn:btih:$hash&dn=$name&tr=$tracker"
+                val link = selected.toMagnetLink(galleryDetail.gid, key)
                 val intent = Intent(Intent.ACTION_VIEW, link.toUri())
                 try {
                     ctx.startActivity(intent)

--- a/app/src/main/kotlin/com/hippo/ehviewer/ui/settings/EhScreen.kt
+++ b/app/src/main/kotlin/com/hippo/ehviewer/ui/settings/EhScreen.kt
@@ -219,6 +219,12 @@ fun AnimatedVisibilityScope.EhScreen(navigator: DestinationsNavigator) = Screen(
                 summary = stringResource(id = R.string.settings_eh_show_reading_progress_summary),
                 state = Settings.showReadingProgress.asMutableState(),
             )
+            SimpleMenuPreferenceInt(
+                title = stringResource(id = R.string.batch_torrent_pick_mode),
+                entry = com.hippo.ehviewer.R.array.batch_torrent_pick_mode_entries,
+                entryValueRes = com.hippo.ehviewer.R.array.batch_torrent_pick_mode_values,
+                state = Settings.batchTorrentPickMode.asMutableState(),
+            )
             SwitchPreference(
                 title = stringResource(id = R.string.settings_eh_show_vote_status),
                 state = Settings.showVoteStatus.asMutableState(),

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -74,6 +74,16 @@
         <item>1</item>
     </integer-array>
 
+    <string-array name="batch_torrent_pick_mode_entries" translatable="false">
+        <item>@string/torrent_pick_largest_size</item>
+        <item>@string/torrent_pick_latest_time</item>
+    </string-array>
+
+    <integer-array name="batch_torrent_pick_mode_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+    </integer-array>
+
     <string-array name="search_min_rating" translatable="false">
         <item>@string/any</item>
         <item>@string/star_2</item>

--- a/core/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/core/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -142,6 +142,10 @@
     <string name="rate_successfully">Rate successfully</string>
     <string name="rate_failed">Rate failed</string>
     <string name="no_torrents">No torrents</string>
+    <string name="copy_torrent_magnet_links">Copy torrent magnet links</string>
+    <string name="batch_torrent_pick_mode">Batch torrent selection</string>
+    <string name="torrent_pick_largest_size">Largest size</string>
+    <string name="torrent_pick_latest_time">Latest time</string>
     <string name="torrents">Torrents</string>
     <string name="not_favorited">Not favorited</string>
     <string name="add_favorites_dialog_title">Add to favorites</string>

--- a/core/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/core/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -126,6 +126,10 @@
     <string name="rate_successfully">评分成功</string>
     <string name="rate_failed">评分失败</string>
     <string name="no_torrents">没有种子</string>
+    <string name="copy_torrent_magnet_links">复制种子磁力链接</string>
+    <string name="batch_torrent_pick_mode">批量种子选择规则</string>
+    <string name="torrent_pick_largest_size">体积最大</string>
+    <string name="torrent_pick_latest_time">时间最新</string>
     <string name="torrents">种子</string>
     <string name="not_favorited">未收藏</string>
     <string name="add_favorites_dialog_title">添加收藏</string>


### PR DESCRIPTION
## Summary

This PR adds batch torrent magnet link copying to the existing Favorites screen selection mode.

Changes included:
- Extract torrent magnet link construction into a reusable helper.
- Add a Favorites selection-mode action for copying torrent magnet links.
- Add a setting for choosing one torrent per gallery when multiple torrents exist:
  - largest size
  - latest time
- Copy selected magnet links to the clipboard as newline-separated text.

## Behavior

The existing single-gallery torrent flow is unchanged:
- the torrent list dialog is still shown on the gallery detail page
- tapping one torrent still opens it with `Intent.ACTION_VIEW`
- if no app can handle the magnet link, the link is still copied to the clipboard

The new batch action only appears in the already existing Favorites multi-selection mode.

## Notes

Each selected gallery contributes at most one magnet link. When a gallery has multiple torrents, the selected torrent follows the new setting.

The batch operation ignores individual gallery failures so one bad gallery does not stop the whole batch.

## Test plan

- `git diff --check`
